### PR TITLE
공통 객체 정의(감사, 응답, 예외)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,41 +1,41 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.2'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.2'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.baedalping'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	//testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    //implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    //testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/baedalping/delivery/DeliveryApplication.java
+++ b/src/main/java/com/baedalping/delivery/DeliveryApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class DeliveryApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(DeliveryApplication.class, args);
-	}
-
+  public static void main(String[] args) {
+    SpringApplication.run(DeliveryApplication.class, args);
+  }
 }

--- a/src/main/java/com/baedalping/delivery/global/common/ApiResponse.java
+++ b/src/main/java/com/baedalping/delivery/global/common/ApiResponse.java
@@ -1,0 +1,36 @@
+package com.baedalping.delivery.global.common;
+
+import com.baedalping.delivery.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor
+public class ApiResponse<T> {
+  private HttpStatus status;
+  private String message;
+  private T data;
+
+  private ApiResponse(HttpStatus status, String message, T data) {
+    this.status = status;
+    this.message = message;
+    this.data = data;
+  }
+
+  public static ApiResponse<Void> error(ErrorCode errorCode) {
+    return new ApiResponse<>(errorCode.getStatus(), errorCode.getMessage(), null);
+  }
+
+  public static <T> ApiResponse<T> error(ErrorCode errorCode, T data) {
+    return new ApiResponse<>(errorCode.getStatus(), errorCode.getMessage(), data);
+  }
+
+  public static <T> ApiResponse<T> created(T data) {
+    return new ApiResponse<>(HttpStatus.CREATED, null, data);
+  }
+
+  public static <T> ApiResponse<T> ok(T data) {
+    return new ApiResponse<>(HttpStatus.OK, null, data);
+  }
+}

--- a/src/main/java/com/baedalping/delivery/global/common/AuditField.java
+++ b/src/main/java/com/baedalping/delivery/global/common/AuditField.java
@@ -9,21 +9,18 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 public abstract class AuditField {
-  @CreatedDate
-  private LocalDateTime createdAt;
+  @CreatedDate private LocalDateTime createdAt;
 
-  @CreatedBy
-  private String createdBy;
+  @CreatedBy private String createdBy;
 
-  @LastModifiedDate
-  private LocalDateTime updatedAt;
+  @LastModifiedDate private LocalDateTime updatedAt;
 
-  @LastModifiedBy
-  private String updatedBy;
+  @LastModifiedBy private String updatedBy;
 
   private LocalDateTime deletedAt;
 

--- a/src/main/java/com/baedalping/delivery/global/common/AuditField.java
+++ b/src/main/java/com/baedalping/delivery/global/common/AuditField.java
@@ -1,0 +1,31 @@
+package com.baedalping.delivery.global.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class AuditField {
+  @CreatedDate
+  private LocalDateTime createdAt;
+
+  @CreatedBy
+  private String createdBy;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+  @LastModifiedBy
+  private String updatedBy;
+
+  private LocalDateTime deletedAt;
+
+  private String deletedBy;
+}

--- a/src/main/java/com/baedalping/delivery/global/common/exception/DeliveryApplicationException.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/DeliveryApplicationException.java
@@ -1,0 +1,15 @@
+package com.baedalping.delivery.global.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeliveryApplicationException extends RuntimeException {
+  private ErrorCode errorCode;
+
+  @Override
+  public String getMessage() {
+    return errorCode.getMessage();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.baedalping.delivery.global.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
+  ;
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/src/main/java/com/baedalping/delivery/global/common/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/ExceptionControllerAdvice.java
@@ -1,0 +1,18 @@
+package com.baedalping.delivery.global.common.exception;
+
+import com.baedalping.delivery.global.common.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ExceptionControllerAdvice {
+  @ExceptionHandler(DeliveryApplicationException.class)
+  public ResponseEntity<?> runtimeExceptionHandler(final DeliveryApplicationException exception) {
+    log.error("Error occurs in {}", exception.toString());
+    return ResponseEntity.status(exception.getErrorCode().getStatus())
+        .body(ApiResponse.error(exception.getErrorCode()));
+  }
+}

--- a/src/main/java/com/baedalping/delivery/global/config/JpaAuditConfig.java
+++ b/src/main/java/com/baedalping/delivery/global/config/JpaAuditConfig.java
@@ -1,0 +1,9 @@
+package com.baedalping.delivery.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditConfig {
+}

--- a/src/main/java/com/baedalping/delivery/global/config/JpaAuditConfig.java
+++ b/src/main/java/com/baedalping/delivery/global/config/JpaAuditConfig.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-public class JpaAuditConfig {
-}
+public class JpaAuditConfig {}

--- a/src/test/java/com/baedalping/delivery/DeliveryApplicationTests.java
+++ b/src/test/java/com/baedalping/delivery/DeliveryApplicationTests.java
@@ -6,8 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class DeliveryApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+  @Test
+  void contextLoads() {}
 }


### PR DESCRIPTION
1. JpaAudit 기능 추가
- JpaAudit Enable을 위한 config 객체 생성
- 생성일, 생성자, 업데이트일, 업데이트자, 삭제일, 삭제자 필드를 공통으로 가지고 있는 추상클래스 AuditField
- 추후 사용시 extends AuditField로 사용, @SqlDelete 처리로 deletedAt 에 갱신해주는 것이 필요함, 조회 시 deletedAt is null인것만 조회가 되도록 해야함

2. 공통 응답객체 ApiResponse 추가 
- 성공이든 실패든 같은 규격으로 응답을 내려줄 수 있도록 정의함 
- 추후 컨트롤러, 전역응답객체에서 사용 

3. 공통 예외처리 객체 추가
- 전역예외를 처리하는 ExceptionControllerAdivce객체 추가 
- 커스텀예외를 만들기 위한 DeliveryApplicationException 정의 
- 커스텀예외를 한번에 관리하는 ErrorCode 정의 