### PR TITLE
Feat/6 redis연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     //implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/baedalping/delivery/global/config/RedisConfig.java
+++ b/src/main/java/com/baedalping/delivery/global/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package com.baedalping.delivery.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Object.class));
+        return template;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,3 +13,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/test/java/com/baedalping/delivery/RedisConnectionTest.java
+++ b/src/test/java/com/baedalping/delivery/RedisConnectionTest.java
@@ -1,0 +1,34 @@
+package com.baedalping.delivery;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("local")
+public class RedisConnectionTest {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    public void testRedisConnection() {
+        // 키-값 설정
+        String key = "testKey";
+        String value = "testValue";
+
+        // Redis에 데이터 저장
+        redisTemplate.opsForValue().set(key, value);
+
+        // Redis에서 데이터 가져오기
+        Object retrievedValue = redisTemplate.opsForValue().get(key);
+
+        // 데이터 검증
+        assertThat(retrievedValue).isEqualTo(value);
+    }
+}
+


### PR DESCRIPTION
1. Redis를 사용하기 위한 의존성 추가

2. Redis Connection을 위한 Bean 설정
- Redis와의 연결을 위한 설정으로 Lettuce 라이브러리 이용

3. Redis와의 상호작용을 위한 RedisTemplate Bean 설정

4. Redis와의 연결을 확인하기 위한 테스트코드 작성 (데이터 저장, 조회)