### PR TITLE
회원가입 API 추가 (#1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    //implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    //testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
@@ -1,0 +1,26 @@
+package com.baedalping.delivery.domain.user.controller;
+
+import com.baedalping.delivery.domain.user.dto.UserCreateRequestDto;
+import com.baedalping.delivery.domain.user.dto.UserCreateResponseDto;
+import com.baedalping.delivery.domain.user.service.UserService;
+import com.baedalping.delivery.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+  private final UserService userService;
+
+  @PostMapping
+  public ApiResponse<UserCreateResponseDto> create(
+      @RequestBody @Validated UserCreateRequestDto requestDto) {
+    return ApiResponse.created(
+        userService.create(requestDto.username(), requestDto.password(), requestDto.email()));
+  }
+}

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/UserCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/UserCreateRequestDto.java
@@ -1,0 +1,18 @@
+package com.baedalping.delivery.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UserCreateRequestDto(
+    @NotBlank(message = "유저이름은 필수값 입니다")
+        @Pattern(
+            regexp = "^[a-z0-9]{4,10}$",
+            message = "유저이름은 영어소문자, 숫자로 이루어진 4자이상 8자 이하의 문자열이어야 합니다")
+        String username,
+    @NotBlank(message = "패스워드는 필수값 입니다")
+        @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[@#$%^&*+=!]).{8,15}$",
+            message = "패스워드는 영어소문자, 숫자, 특수문자로 이루어진 8자 이상 15자 이하의 문자열이어야 합니다")
+        String password,
+    @NotBlank(message = "유저이메일은 필수값 입니다") @Email(message = "이메일 형식에 맞지 않습니다") String email) {}

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/UserCreateResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/UserCreateResponseDto.java
@@ -1,0 +1,53 @@
+package com.baedalping.delivery.domain.user.dto;
+
+import com.baedalping.delivery.domain.user.entity.User;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserCreateResponseDto {
+  private Long userId;
+  private String userName;
+  private String email;
+  private String userRole;
+  private boolean isPublic;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private LocalDateTime deletedAt;
+
+  @Builder
+  private UserCreateResponseDto(
+      Long userId,
+      String userName,
+      String email,
+      String userRole,
+      boolean isPublic,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt,
+      LocalDateTime deletedAt) {
+    this.userId = userId;
+    this.userName = userName;
+    this.email = email;
+    this.userRole = userRole;
+    this.isPublic = isPublic;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.deletedAt = deletedAt;
+  }
+
+  public static UserCreateResponseDto ofEntity(User user) {
+    return UserCreateResponseDto.builder()
+        .userId(user.getUserId())
+        .userName(user.getUsername())
+        .email(user.getEmail())
+        .userRole(user.getRole().getRoleName())
+        .isPublic(user.isPublic())
+        .createdAt(user.getCreatedAt())
+        .updatedAt(user.getUpdatedAt())
+        .deletedAt(user.getDeletedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
@@ -52,7 +52,7 @@ public class User extends AuditField {
   private boolean isPublic = false;
 
   @Builder
-  public User(String username, String password, String email) {
+  private User(String username, String password, String email) {
     this.username = username;
     this.password = password;
     this.email = email;

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
@@ -1,0 +1,71 @@
+package com.baedalping.delivery.domain.user.entity;
+
+import com.baedalping.delivery.global.common.AuditField;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "P_USERS")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at is NULL")
+public class User extends AuditField {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "user_id")
+  private Long userId;
+
+  @Column(name = "username", nullable = false)
+  private String username;
+
+  @Column(name = "password", nullable = false)
+  private String password;
+
+  @Column(unique = true, nullable = false)
+  @Email
+  private String email;
+
+  @Column(name = "role")
+  @Enumerated(EnumType.STRING)
+  private UserRole role = UserRole.CUSTOMER;
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<UserAddress> addressList = new ArrayList<>();
+
+  @Column(name = "is_public", nullable = false)
+  private boolean isPublic = false;
+
+  @Builder
+  public User(String username, String password, String email) {
+    this.username = username;
+    this.password = password;
+    this.email = email;
+  }
+
+  public void updateUserRole(UserRole role) {
+    this.role = role;
+  }
+
+  public void isPublic(){
+    this.isPublic = true;
+  }
+
+  public void addAddress(UserAddress address) {
+    addressList.add(address);
+    address.setUser(this);
+  }
+}

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
@@ -49,7 +49,7 @@ public class User extends AuditField {
   private final List<UserAddress> addressList = new ArrayList<>();
 
   @Column(name = "is_public", nullable = false)
-  private boolean isPublic = false;
+  private boolean isPublic = true;
 
   @Builder
   private User(String username, String password, String email) {
@@ -62,8 +62,8 @@ public class User extends AuditField {
     this.role = role;
   }
 
-  public void setPublicUser() {
-    this.isPublic = true;
+  public void setInvisible() {
+    this.isPublic = false;
   }
 
   public void addAddress(UserAddress address) {

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -23,6 +24,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Table(name = "P_USERS")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("deleted_at is NULL")
+@Getter
 public class User extends AuditField {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,7 +46,7 @@ public class User extends AuditField {
   private UserRole role = UserRole.CUSTOMER;
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<UserAddress> addressList = new ArrayList<>();
+  private final List<UserAddress> addressList = new ArrayList<>();
 
   @Column(name = "is_public", nullable = false)
   private boolean isPublic = false;
@@ -60,7 +62,7 @@ public class User extends AuditField {
     this.role = role;
   }
 
-  public void isPublic(){
+  public void setPublicUser() {
     this.isPublic = true;
   }
 

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
@@ -1,0 +1,50 @@
+package com.baedalping.delivery.domain.user.entity;
+
+import com.baedalping.delivery.global.common.AuditField;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Table(name = "P_USER_ADDRESS")
+@Entity
+@NoArgsConstructor
+@SQLRestriction("deleted_at is NULL")
+public class UserAddress extends AuditField {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "address_id")
+  private UUID addressId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(name = "address", nullable = false)
+  private String address;
+
+  @Column(name = "zipcode", nullable = false, length = 5)
+  private String zipcode;
+
+  @Column(name = "address_alias", nullable = true)
+  private String alias;
+
+  @Builder
+  private UserAddress(User user, String address, String zipcode, String alias) {
+    this.user = user;
+    this.address = address;
+    this.zipcode = zipcode;
+    this.alias = alias;
+  }
+  public void setUser(User user){
+    this.user = user;
+  }
+}

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
@@ -24,6 +24,7 @@ public class UserAddress extends AuditField {
   @GeneratedValue(strategy = GenerationType.UUID)
   @Column(name = "address_id")
   private UUID addressId;
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
@@ -44,7 +45,8 @@ public class UserAddress extends AuditField {
     this.zipcode = zipcode;
     this.alias = alias;
   }
-  public void setUser(User user){
+
+  public void setUser(User user) {
     this.user = user;
   }
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/UserRole.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/UserRole.java
@@ -1,0 +1,18 @@
+package com.baedalping.delivery.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum UserRole {
+  CUSTOMER(101, "CUSTOMER"),
+  OWNER(102, "OWNER"),
+
+  MANAGER(201, "MANAGER"),
+  ADMIN(202, "ADMIN")
+  ;
+
+  private long roleNum;
+  private String roleName;
+}

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/UserRole.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/UserRole.java
@@ -10,8 +10,7 @@ public enum UserRole {
   OWNER(102, "OWNER"),
 
   MANAGER(201, "MANAGER"),
-  ADMIN(202, "ADMIN")
-  ;
+  ADMIN(202, "ADMIN");
 
   private long roleNum;
   private String roleName;

--- a/src/main/java/com/baedalping/delivery/domain/user/repository/UserAddressRepository.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/repository/UserAddressRepository.java
@@ -1,0 +1,7 @@
+package com.baedalping.delivery.domain.user.repository;
+
+import com.baedalping.delivery.domain.user.entity.UserAddress;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAddressRepository extends JpaRepository<UserAddress, UUID> {}

--- a/src/main/java/com/baedalping/delivery/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/repository/UserRepository.java
@@ -5,5 +5,6 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-  Optional<User> findByEmail(String email);
+  Optional<User> findByUserId(Long userId);
+  boolean existsByEmail(String email);
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.baedalping.delivery.domain.user.repository;
+
+import com.baedalping.delivery.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+  Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
@@ -1,0 +1,36 @@
+package com.baedalping.delivery.domain.user.service;
+
+import com.baedalping.delivery.domain.user.dto.UserCreateResponseDto;
+import com.baedalping.delivery.domain.user.entity.User;
+import com.baedalping.delivery.domain.user.repository.UserRepository;
+import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
+import com.baedalping.delivery.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+  private final UserRepository userRepository;
+  private final BCryptPasswordEncoder encoder;
+
+  @Transactional
+  public UserCreateResponseDto create(String username, String password, String email) {
+    validateUniqueEmail(email);
+    User newUser =
+        User.builder().username(username).password(encoder.encode(password)).email(email).build();
+    return UserCreateResponseDto.ofEntity(userRepository.save(newUser));
+  }
+
+  private void validateUniqueEmail(String email) {
+    userRepository
+        .findByEmail(email)
+        .ifPresent(
+            user -> {
+              throw new DeliveryApplicationException(ErrorCode.DUPLICATED_USER);
+            });
+  }
+}

--- a/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
@@ -26,11 +26,8 @@ public class UserService {
   }
 
   private void validateUniqueEmail(String email) {
-    userRepository
-        .findByEmail(email)
-        .ifPresent(
-            user -> {
-              throw new DeliveryApplicationException(ErrorCode.DUPLICATED_USER);
-            });
+    if (userRepository.existsByEmail(email)) {
+      throw new DeliveryApplicationException(ErrorCode.DUPLICATED_USER);
+    }
   }
 }

--- a/src/main/java/com/baedalping/delivery/global/common/ApiResponse.java
+++ b/src/main/java/com/baedalping/delivery/global/common/ApiResponse.java
@@ -9,10 +9,10 @@ import org.springframework.http.HttpStatus;
 @NoArgsConstructor
 public class ApiResponse<T> {
   private HttpStatus status;
-  private String message;
+  private Object message;
   private T data;
 
-  private ApiResponse(HttpStatus status, String message, T data) {
+  private ApiResponse(HttpStatus status, Object message, T data) {
     this.status = status;
     this.message = message;
     this.data = data;
@@ -24,6 +24,10 @@ public class ApiResponse<T> {
 
   public static <T> ApiResponse<T> error(ErrorCode errorCode, T data) {
     return new ApiResponse<>(errorCode.getStatus(), errorCode.getMessage(), data);
+  }
+
+  public static ApiResponse<Void> error(HttpStatus httpStatus, Object message) {
+    return new ApiResponse<>(httpStatus, message, null);
   }
 
   public static <T> ApiResponse<T> created(T data) {

--- a/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
   NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
+  DUPLICATED_USER(HttpStatus.CONFLICT, "이미 가입된 유저 이메일 입니다"),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/baedalping/delivery/global/common/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/ExceptionControllerAdvice.java
@@ -2,7 +2,9 @@ package com.baedalping.delivery.global.common.exception;
 
 import com.baedalping.delivery.global.common.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,5 +16,16 @@ public class ExceptionControllerAdvice {
     log.error("Error occurs in {}", exception.toString());
     return ResponseEntity.status(exception.getErrorCode().getStatus())
         .body(ApiResponse.error(exception.getErrorCode()));
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<?> validationExceptionHandler(final MethodArgumentNotValidException e) {
+    log.error("Validation error occurs in {}", e.toString());
+    String[] errorMessages =
+        e.getBindingResult().getFieldErrors().stream()
+            .map(error -> String.format("[%s]: %s", error.getField(), error.getDefaultMessage()))
+            .toArray(String[]::new);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ApiResponse.error(HttpStatus.BAD_REQUEST, errorMessages));
   }
 }

--- a/src/main/java/com/baedalping/delivery/global/config/PasswordEncoder.java
+++ b/src/main/java/com/baedalping/delivery/global/config/PasswordEncoder.java
@@ -1,0 +1,13 @@
+package com.baedalping.delivery.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoder {
+  @Bean
+  public BCryptPasswordEncoder passwordEncoder(){
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/global/config/PasswordEncoder.java
+++ b/src/main/java/com/baedalping/delivery/global/config/PasswordEncoder.java
@@ -7,7 +7,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 @Configuration
 public class PasswordEncoder {
   @Bean
-  public BCryptPasswordEncoder passwordEncoder(){
+  public BCryptPasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
   }
 }

--- a/src/main/java/com/baedalping/delivery/global/config/PasswordEncoder.java
+++ b/src/main/java/com/baedalping/delivery/global/config/PasswordEncoder.java
@@ -7,7 +7,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 @Configuration
 public class PasswordEncoder {
   @Bean
-  public BCryptPasswordEncoder passwordEncoder() {
+  public BCryptPasswordEncoder encoder() {
     return new BCryptPasswordEncoder();
   }
 }

--- a/src/test/java/com/baedalping/delivery/user/UserControllerTest.java
+++ b/src/test/java/com/baedalping/delivery/user/UserControllerTest.java
@@ -1,0 +1,67 @@
+package com.baedalping.delivery.user;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.baedalping.delivery.domain.user.controller.UserController;
+import com.baedalping.delivery.domain.user.dto.UserCreateRequestDto;
+import com.baedalping.delivery.domain.user.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+public class UserControllerTest {
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockBean private UserService userService;
+
+  @Test
+  @WithMockUser
+  public void 받아온_유저정보로_회원가입에_성공한다() throws Exception {
+    String username = "username";
+    String password = "password123**";
+    String email = "email@test.com";
+
+    UserCreateRequestDto requestDto = new UserCreateRequestDto(username, password, email);
+
+    mockMvc
+        .perform(
+            post("/users")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(requestDto)))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser
+  public void 입력값_검증에_실패하여_회원가입에_실패한다() throws Exception {
+    String username = ""; // 공백, 유저네임 정책에 맞지 않음
+    String password = "password"; // 패스워드 정책에 맞지 않음
+    String email = "emailtest.com"; // 이메일 형식에 맞지 않음
+
+    UserCreateRequestDto requestDto = new UserCreateRequestDto(username, password, email);
+
+    mockMvc
+        .perform(
+            post("/users")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(requestDto)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message", hasSize(4)))
+        .andDo(print());
+  }
+}

--- a/src/test/java/com/baedalping/delivery/user/UserServiceTest.java
+++ b/src/test/java/com/baedalping/delivery/user/UserServiceTest.java
@@ -1,0 +1,42 @@
+package com.baedalping.delivery.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.baedalping.delivery.domain.user.entity.User;
+import com.baedalping.delivery.domain.user.repository.UserRepository;
+import com.baedalping.delivery.domain.user.service.UserService;
+import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+  @Mock private UserRepository userRepository;
+  @Mock private BCryptPasswordEncoder encoder;
+  @InjectMocks private UserService userService;
+
+  @Test
+  void 이메일이_중복되어_회원가입에_실패한다() {
+    String username = "username";
+    String password = "pass123***";
+    String duplicatedEmail = "test@test.com";
+
+    when(userRepository.findByEmail(duplicatedEmail)).thenReturn(Optional.of(mock(User.class)));
+    DeliveryApplicationException exception =
+        assertThrows(
+            DeliveryApplicationException.class,
+            () -> userService.create(username, password, duplicatedEmail));
+
+    assertEquals(exception.getErrorCode().getStatus(), HttpStatus.CONFLICT);
+    assertEquals(exception.getErrorCode().getMessage(), "이미 가입된 유저 이메일 입니다");
+  }
+}


### PR DESCRIPTION
- issue #1 
- 유저 도메인 클래스 정의(User, UserRole, UserAddress)
- 회원가입 시 request로 username, password, email 값을 받고 dto에서 입력값 검증 진행
- 패스워드 인코딩을 위한 BCrypt 빈 추가 
- 회원가입 시 service에서 email 중복체크 진행 
- 컨트롤러, 서비스 테스트 코드 추가 
<img width="237" alt="image" src="https://github.com/user-attachments/assets/2fca9963-eef8-4d5f-939d-2bafde406603">
<img width="233" alt="image" src="https://github.com/user-attachments/assets/72ae508f-6b00-4f91-ba9b-b6e9dea244a9">