### PR TITLE
유저정보 수정 API 구현 (#13)

### DIFF
--- a/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
@@ -2,11 +2,14 @@ package com.baedalping.delivery.domain.user.controller;
 
 import com.baedalping.delivery.domain.user.dto.UserCreateRequestDto;
 import com.baedalping.delivery.domain.user.dto.UserCreateResponseDto;
+import com.baedalping.delivery.domain.user.dto.UserUpdateRequestDto;
+import com.baedalping.delivery.domain.user.dto.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.service.UserService;
 import com.baedalping.delivery.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,5 +25,14 @@ public class UserController {
       @RequestBody @Validated UserCreateRequestDto requestDto) {
     return ApiResponse.created(
         userService.create(requestDto.username(), requestDto.password(), requestDto.email()));
+  }
+
+  @PutMapping
+  public ApiResponse<UserUpdateResponseDto> update(
+      @RequestBody @Validated UserUpdateRequestDto requestDto) {
+    Long userId = 1L; // TODO :: spring security 적용 이후 principle로 userId 검증 추가
+    return ApiResponse.ok(
+        userService.updateUserInfo(
+            userId, requestDto.username(), requestDto.password(), requestDto.email()));
   }
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/UserUpdateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/UserUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package com.baedalping.delivery.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UserUpdateRequestDto(
+    @NotBlank(message = "유저이름은 필수값 입니다")
+        @Pattern(
+            regexp = "^[a-z0-9]{4,10}$",
+            message = "유저이름은 영어소문자, 숫자로 이루어진 4자이상 8자 이하의 문자열이어야 합니다")
+        String username,
+    @NotBlank(message = "패스워드는 필수값 입니다")
+        @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[@#$%^&*+=!]).{8,15}$",
+            message = "패스워드는 영어소문자, 숫자, 특수문자로 이루어진 8자 이상 15자 이하의 문자열이어야 합니다")
+        String password,
+    @NotBlank(message = "유저이메일은 필수값 입니다") @Email(message = "이메일 형식에 맞지 않습니다") String email) {}

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/UserUpdateResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/UserUpdateResponseDto.java
@@ -1,0 +1,49 @@
+package com.baedalping.delivery.domain.user.dto;
+
+import com.baedalping.delivery.domain.user.entity.User;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserUpdateResponseDto {
+  private Long userId;
+  private String userName;
+  private String email;
+  private String userRole;
+  private boolean isPublic;
+  private LocalDateTime updatedAt;
+  private String updatedBy;
+
+  @Builder
+  private UserUpdateResponseDto(
+      Long userId,
+      String userName,
+      String email,
+      String userRole,
+      boolean isPublic,
+      LocalDateTime updatedAt,
+      String updatedBy) {
+    this.userId = userId;
+    this.userName = userName;
+    this.email = email;
+    this.userRole = userRole;
+    this.isPublic = isPublic;
+    this.updatedAt = updatedAt;
+    this.updatedBy = updatedBy;
+  }
+
+  public static UserUpdateResponseDto ofEntity(User user) {
+    return UserUpdateResponseDto.builder()
+        .userId(user.getUserId())
+        .userName(user.getUsername())
+        .email(user.getEmail())
+        .userRole(user.getRole().getRoleName())
+        .isPublic(user.isPublic())
+        .updatedAt(user.getUpdatedAt())
+        .updatedBy(user.getUpdatedBy())
+        .build();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
@@ -58,6 +58,12 @@ public class User extends AuditField {
     this.email = email;
   }
 
+  public void updateInfo(String username, String password, String email) {
+    this.username = username;
+    this.password = password;
+    this.email = email;
+  }
+
   public void updateUserRole(UserRole role) {
     this.role = role;
   }

--- a/src/main/java/com/baedalping/delivery/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/repository/UserRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByUserId(Long userId);
+
   boolean existsByEmail(String email);
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
@@ -27,9 +27,12 @@ public class UserService {
   }
 
   @Transactional
-  public UserUpdateResponseDto updateUserInfo(Long userId, String username, String password, String email){
-    User user = userRepository.findByUserId(userId)
-        .orElseThrow(() -> new DeliveryApplicationException(ErrorCode.NOT_FOUND_USER));
+  public UserUpdateResponseDto updateUserInfo(
+      Long userId, String username, String password, String email) {
+    User user =
+        userRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new DeliveryApplicationException(ErrorCode.NOT_FOUND_USER));
 
     user.updateInfo(username, encoder.encode(password), email);
     userRepository.saveAndFlush(user);

--- a/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.baedalping.delivery.domain.user.service;
 
 import com.baedalping.delivery.domain.user.dto.UserCreateResponseDto;
+import com.baedalping.delivery.domain.user.dto.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.entity.User;
 import com.baedalping.delivery.domain.user.repository.UserRepository;
 import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
@@ -23,6 +24,17 @@ public class UserService {
     User newUser =
         User.builder().username(username).password(encoder.encode(password)).email(email).build();
     return UserCreateResponseDto.ofEntity(userRepository.save(newUser));
+  }
+
+  @Transactional
+  public UserUpdateResponseDto updateUserInfo(Long userId, String username, String password, String email){
+    User user = userRepository.findByUserId(userId)
+        .orElseThrow(() -> new DeliveryApplicationException(ErrorCode.NOT_FOUND_USER));
+
+    user.updateInfo(username, encoder.encode(password), email);
+    userRepository.saveAndFlush(user);
+
+    return UserUpdateResponseDto.ofEntity(user);
   }
 
   private void validateUniqueEmail(String email) {

--- a/src/main/java/com/baedalping/delivery/global/common/AuthenticationConfig.java
+++ b/src/main/java/com/baedalping/delivery/global/common/AuthenticationConfig.java
@@ -1,0 +1,19 @@
+package com.baedalping.delivery.global.common;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class AuthenticationConfig {
+  @Bean
+  protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.csrf(CsrfConfigurer -> CsrfConfigurer.disable())
+        .authorizeHttpRequests(
+            (authorizeRequests) -> authorizeRequests.requestMatchers("/users/**").permitAll());
+    return http.build();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
@@ -9,11 +9,10 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
   NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
   DUPLICATED_USER(HttpStatus.CONFLICT, "이미 가입된 유저 이메일 입니다"),
-  ;
-    // Cart
-    CART_ONLY_ONE_STORE_ALLOWED(HttpStatus.BAD_REQUEST, "한 번에 하나의 가게의 상품만 담을 수 있습니다."),
-    NOT_FOUND_PRODUCT_IN_CART(HttpStatus.NOT_FOUND, "장바구니에 해당 상품이 존재하지 않습니다.");
 
-    private final HttpStatus status;
-    private final String message;
+  CART_ONLY_ONE_STORE_ALLOWED(HttpStatus.BAD_REQUEST, "한 번에 하나의 가게의 상품만 담을 수 있습니다."),
+  NOT_FOUND_PRODUCT_IN_CART(HttpStatus.NOT_FOUND, "장바구니에 해당 상품이 존재하지 않습니다.");
+
+  private final HttpStatus status;
+  private final String message;
 }

--- a/src/main/java/com/baedalping/delivery/global/config/AuditorAwareImpl.java
+++ b/src/main/java/com/baedalping/delivery/global/config/AuditorAwareImpl.java
@@ -1,0 +1,12 @@
+package com.baedalping.delivery.global.config;
+
+import java.util.Optional;
+import org.springframework.data.domain.AuditorAware;
+
+public class AuditorAwareImpl implements AuditorAware<String> {
+  @Override
+  public Optional<String> getCurrentAuditor() {
+    //TODO :: principle 적용시 유저name 가져와서 저장하는것으로 구현
+    return Optional.empty();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/global/config/JpaAuditConfig.java
+++ b/src/main/java/com/baedalping/delivery/global/config/JpaAuditConfig.java
@@ -1,8 +1,15 @@
 package com.baedalping.delivery.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
-@EnableJpaAuditing
-public class JpaAuditConfig {}
+@EnableJpaAuditing(auditorAwareRef = "auditorAware")
+public class JpaAuditConfig {
+  @Bean
+  public AuditorAware<String> auditorAware(){
+    return new AuditorAwareImpl();
+  }
+}

--- a/src/test/java/com/baedalping/delivery/user/UserServiceTest.java
+++ b/src/test/java/com/baedalping/delivery/user/UserServiceTest.java
@@ -1,10 +1,11 @@
 package com.baedalping.delivery.user;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.baedalping.delivery.domain.user.dto.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.entity.User;
 import com.baedalping.delivery.domain.user.repository.UserRepository;
 import com.baedalping.delivery.domain.user.service.UserService;
@@ -30,7 +31,7 @@ public class UserServiceTest {
     String password = "pass123***";
     String duplicatedEmail = "test@test.com";
 
-    when(userRepository.findByEmail(duplicatedEmail)).thenReturn(Optional.of(mock(User.class)));
+    when(userRepository.existsByEmail(duplicatedEmail)).thenReturn(Boolean.TRUE);
     DeliveryApplicationException exception =
         assertThrows(
             DeliveryApplicationException.class,
@@ -38,5 +39,33 @@ public class UserServiceTest {
 
     assertEquals(exception.getErrorCode().getStatus(), HttpStatus.CONFLICT);
     assertEquals(exception.getErrorCode().getMessage(), "이미 가입된 유저 이메일 입니다");
+  }
+
+  @Test
+  void 유저정보_업데이트에_성공한다() {
+    Long userId = 1L;
+    String username = "updatename";
+    String password = "newpass123@@";
+    String email = "test@test.com";
+    User user = User.builder().email(email).password(password).email(email).build();
+    when(userRepository.findByUserId(userId)).thenReturn(Optional.of(user));
+    UserUpdateResponseDto response = userService.updateUserInfo(userId, username, password, email);
+    assertThat(response.getUserName()).isEqualTo(username);
+  }
+
+  @Test
+  void 유저정보_업데이트시_유저정보를_찾을수없어_실패한다() {
+    Long userId = 1L;
+    String username = "username";
+    String password = "pass123***";
+    String email = "test@test.com";
+
+    when(userRepository.findByUserId(userId)).thenReturn(Optional.empty());
+    DeliveryApplicationException exception =
+        assertThrows(
+            DeliveryApplicationException.class,
+            () -> userService.updateUserInfo(userId, username, password, email));
+    assertEquals(exception.getErrorCode().getStatus(), HttpStatus.NOT_FOUND);
+    assertEquals(exception.getErrorCode().getMessage(), "가입된 유저가 아닙니다");
   }
 }


### PR DESCRIPTION
- issues #13 
- Jpa 더티체킹을 이용한 유저정보 업데이트 
- updateAt 갱신을 위해 리포지토리 saveAndFlush 적용
- 임시로 포스트맨 테스트를 용이하게 하기 위해 filterchain 빈에 /users 경로를 permitAll 해줌 (추후 수정예정)
- Audit필드에 유저네임을 넣어주는 빈 미리 등록
- 서비스테스트로 성공, 유저낫파운드 예외만 진행 
<img width="453" alt="image" src="https://github.com/user-attachments/assets/ab0ba63c-a8ca-45b0-b33d-026db86cb594">
<img width="489" alt="image" src="https://github.com/user-attachments/assets/56d21035-5270-4860-9126-df136e007653">
