### PR TITLE
Feat/3 연관관계 수정, 가게, 가게분류, 상품, 상품 분류 생성

### DIFF
--- a/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
@@ -8,7 +8,14 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
   NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
-  ;
+
+  NOT_FOUND_STORE_CATEGORY(HttpStatus.NOT_FOUND, "가게 분류를 찾을 수 없습니다."),
+  DUPLICATE_STORE_CATEGORY_NAME(HttpStatus.NOT_FOUND, "가게 분류가 중복되었습니다."),
+
+  NOT_FOUND_STORE(HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다."),
+
+  DUPLICATE_PRODUCT_CATEGORY_NAME(HttpStatus.NOT_FOUND, "상품 분류가 중복되었습니다."),
+  NOT_FOUND_PRODUCT_CATEGORY(HttpStatus.NOT_FOUND, "상품 분류를 찾을 수 없습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/baedalping/delivery/product/Product.java
+++ b/src/main/java/com/baedalping/delivery/product/Product.java
@@ -7,8 +7,6 @@ import com.baedalping.delivery.store.Store;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
@@ -24,7 +22,7 @@ public class Product extends AuditField {
     @Column(nullable = false)
     private String productName;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_category_id", nullable = false)
     private ProductCategory productCategory;
 
@@ -47,6 +45,20 @@ public class Product extends AuditField {
     public void addStore(Store store){
         this.store = store;
         store.getProductList().add(this);
+    }
+
+    public void addProductCategory(ProductCategory productCategory){
+        this.productCategory = productCategory;
+        productCategory.getProductList().add(this);
+    }
+
+    public Product(ProductCreateRequestDto productCreateRequestDto, ProductCategory productCategory, Store store){
+        this.productName = productCreateRequestDto.getProductName();
+        this.productCategory = productCategory;
+        this.store = store;
+        this.productPrice = productCreateRequestDto.getProductPrice();
+        this.productDetail = productCreateRequestDto.getProductDetail();
+        this.productImgUrl = productCreateRequestDto.getProductImgUrl();
     }
 
 }

--- a/src/main/java/com/baedalping/delivery/product/ProductController.java
+++ b/src/main/java/com/baedalping/delivery/product/ProductController.java
@@ -1,0 +1,21 @@
+package com.baedalping.delivery.product;
+
+import com.baedalping.delivery.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/products")
+@RequiredArgsConstructor
+@RestController
+public class ProductController {
+
+  private final ProductService productService;
+
+  @PostMapping
+  public ApiResponse<ProductCreateResponseDto> createProduct(@RequestBody ProductCreateRequestDto productCreateRequestDto){
+    return ApiResponse.created(productService.createProduct(productCreateRequestDto));
+  }
+}

--- a/src/main/java/com/baedalping/delivery/product/ProductCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/product/ProductCreateRequestDto.java
@@ -1,0 +1,18 @@
+package com.baedalping.delivery.product;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProductCreateRequestDto {
+  private String productName;
+  private Integer productPrice;
+  private String productDetail;
+  private String productImgUrl;
+  private UUID storeId;
+  private UUID productCategoryId;
+}

--- a/src/main/java/com/baedalping/delivery/product/ProductCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/product/ProductCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.baedalping.delivery.product;
 
+import jakarta.validation.constraints.NotBlank;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,9 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class ProductCreateRequestDto {
+  @NotBlank(message = "상품명을 입력해주세요.")
   private String productName;
+  @NotBlank(message = "상품 가격을 입력해주세요.")
   private Integer productPrice;
   private String productDetail;
   private String productImgUrl;

--- a/src/main/java/com/baedalping/delivery/product/ProductCreateResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/product/ProductCreateResponseDto.java
@@ -1,0 +1,27 @@
+package com.baedalping.delivery.product;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductCreateResponseDto {
+  private UUID productId;
+  private String productName;
+  private Integer productPrice;
+  private String productDetail;
+  private String productImgUrl;
+  private UUID storeId;
+  private UUID categoryId;
+
+  public ProductCreateResponseDto(Product product){
+    this.productId = product.getProductId();
+    this.productName = product.getProductName();
+    this.productPrice = product.getProductPrice();
+    this.productDetail = product.getProductDetail();
+    this.productImgUrl = product.getProductImgUrl();
+    this.storeId = product.getStore().getStoreId();
+    this.categoryId = product.getProductCategory().getProductCategoryId();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/product/ProductService.java
+++ b/src/main/java/com/baedalping/delivery/product/ProductService.java
@@ -1,0 +1,39 @@
+package com.baedalping.delivery.product;
+
+
+import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
+import com.baedalping.delivery.global.common.exception.ErrorCode;
+import com.baedalping.delivery.productCategory.ProductCategory;
+import com.baedalping.delivery.productCategory.ProductCategoryRepository;
+import com.baedalping.delivery.store.Store;
+import com.baedalping.delivery.store.StoreRepository;
+import jakarta.transaction.Transactional;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class ProductService {
+
+  private final ProductRepository productRepository;
+  private final ProductCategoryRepository productCategoryRepository;
+  private final StoreRepository storeRepository;
+
+  @Transactional
+  public ProductCreateResponseDto createProduct(ProductCreateRequestDto productCreateRequestDto) {
+    UUID productCategoryId = productCreateRequestDto.getProductCategoryId();
+    ProductCategory productCategory = productCategoryRepository.findById(productCategoryId).orElseThrow(
+        () -> new DeliveryApplicationException(ErrorCode.NOT_FOUND_PRODUCT_CATEGORY)
+    );
+
+    UUID storeId = productCreateRequestDto.getStoreId();
+    Store store = storeRepository.findById(storeId).orElseThrow(
+        () -> new DeliveryApplicationException(ErrorCode.NOT_FOUND_STORE)
+    );
+
+    Product product = productRepository.save(new Product(productCreateRequestDto, productCategory, store));
+    return new ProductCreateResponseDto(product);
+  }
+
+}

--- a/src/main/java/com/baedalping/delivery/productCategory/ProductCategory.java
+++ b/src/main/java/com/baedalping/delivery/productCategory/ProductCategory.java
@@ -1,11 +1,12 @@
 package com.baedalping.delivery.productCategory;
 
 import com.baedalping.delivery.global.common.AuditField;
+import com.baedalping.delivery.product.Product;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
@@ -18,8 +19,15 @@ public class ProductCategory extends AuditField {
     @Column(name = "product_category_id")
     private UUID productCategoryId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String productCategoryName;
 
+    @OneToMany(mappedBy = "productCategory")
+    private List<Product> productList = new ArrayList<>();
+
     private boolean isPublic = true;
+
+    public ProductCategory(ProductCategoryCreateRequestDto productCategoryCreateRequestDto){
+        this.productCategoryName = productCategoryCreateRequestDto.getProductCategoryName();
+    }
 }

--- a/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryController.java
+++ b/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryController.java
@@ -1,0 +1,21 @@
+package com.baedalping.delivery.productCategory;
+
+import com.baedalping.delivery.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/productCategories")
+@RequiredArgsConstructor
+@RestController
+public class ProductCategoryController {
+
+  private final ProductCategoryService productCategoryService;
+
+  @PostMapping
+  public ApiResponse<ProductCategoryCreateResponseDto> createProductCategory(@RequestBody ProductCategoryCreateRequestDto productCategoryCreateRequestDto){
+    return ApiResponse.created(productCategoryService.createProductCategory(productCategoryCreateRequestDto));
+  }
+}

--- a/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.baedalping.delivery.productCategory;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,5 +9,6 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 public class ProductCategoryCreateRequestDto {
+  @NotBlank(message = "상품 분류명을 입력해주세요.")
   private String productCategoryName;
 }

--- a/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryCreateRequestDto.java
@@ -1,0 +1,12 @@
+package com.baedalping.delivery.productCategory;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+public class ProductCategoryCreateRequestDto {
+  private String productCategoryName;
+}

--- a/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryCreateResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryCreateResponseDto.java
@@ -1,0 +1,17 @@
+package com.baedalping.delivery.productCategory;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductCategoryCreateResponseDto {
+  private UUID productCategoryId;
+  private String productCategoryName;
+
+  public ProductCategoryCreateResponseDto(ProductCategory productCategory){
+    this.productCategoryId = productCategory.getProductCategoryId();
+    this.productCategoryName = productCategory.getProductCategoryName();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryRepository.java
+++ b/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryRepository.java
@@ -1,8 +1,10 @@
 package com.baedalping.delivery.productCategory;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface ProductCategoryRepository extends JpaRepository<ProductCategory, UUID> {
+  Optional<ProductCategory> findByProductCategoryName(String producCategoryName);
 }

--- a/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryService.java
+++ b/src/main/java/com/baedalping/delivery/productCategory/ProductCategoryService.java
@@ -1,0 +1,29 @@
+package com.baedalping.delivery.productCategory;
+
+
+
+import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
+import com.baedalping.delivery.global.common.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class ProductCategoryService {
+
+  private final ProductCategoryRepository productCategoryRepository;
+
+  @Transactional
+  public ProductCategoryCreateResponseDto createProductCategory(ProductCategoryCreateRequestDto productCategoryCreateRequestDto) {
+    String productCategoryName = productCategoryCreateRequestDto.getProductCategoryName();
+    if(productCategoryRepository.findByProductCategoryName(productCategoryName).isPresent()) {
+      new DeliveryApplicationException(ErrorCode.DUPLICATE_PRODUCT_CATEGORY_NAME);
+    }
+
+    ProductCategory productCategory = productCategoryRepository.save(new ProductCategory(productCategoryCreateRequestDto));
+    return new ProductCategoryCreateResponseDto(productCategory);
+  }
+
+
+}

--- a/src/main/java/com/baedalping/delivery/store/Store.java
+++ b/src/main/java/com/baedalping/delivery/store/Store.java
@@ -2,7 +2,6 @@ package com.baedalping.delivery.store;
 
 import com.baedalping.delivery.global.common.AuditField;
 import com.baedalping.delivery.product.Product;
-import com.baedalping.delivery.productCategory.ProductCategory;
 import com.baedalping.delivery.storeCategory.StoreCategory;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -12,11 +11,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.math.BigDecimal;
-import java.sql.Time;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -40,11 +38,11 @@ public class Store extends AuditField {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;*/
 
-  @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "store_category_id",nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "store_category_id", nullable = false)
   private StoreCategory storeCategory;
 
-  @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Product> productList = new ArrayList<>();
 
   private String storePhone;
@@ -54,10 +52,26 @@ public class Store extends AuditField {
   @Column(columnDefinition = "TEXT")
   private String storeDetail;
 
-  private Time openTime;
+  private LocalTime openTime;
 
-  private Time closeTime;
+  private LocalTime closeTime;
 
   private boolean isPublic = true;
+
+
+  public void addStoreCategory(StoreCategory storeCategory){
+    this.storeCategory = storeCategory;
+    storeCategory.getStoreList().add(this);
+  }
+
+  public Store(StoreCreateRequestDto storeCreateRequestDto, StoreCategory storeCategory){
+    this.storeName = storeCreateRequestDto.getStoreName();
+    this.storePhone = storeCreateRequestDto.getStorePhone();
+    this.storeAddress = storeCreateRequestDto.getStoreAddress();
+    this.storeDetail = storeCreateRequestDto.getStoreDetail();
+    this.openTime = storeCreateRequestDto.getOpenTime();
+    this.closeTime = storeCreateRequestDto.getCloseTime();
+    this.storeCategory = storeCategory;
+  }
 
 }

--- a/src/main/java/com/baedalping/delivery/store/StoreController.java
+++ b/src/main/java/com/baedalping/delivery/store/StoreController.java
@@ -1,0 +1,24 @@
+package com.baedalping.delivery.store;
+
+import com.baedalping.delivery.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequestMapping("/stores")
+@RequiredArgsConstructor
+@RestController
+public class StoreController {
+
+  private final StoreService storeService;
+
+  @PostMapping
+  public ApiResponse<StoreCreateResponseDto> createStore(@RequestBody StoreCreateRequestDto storeCreateRequestDto){
+    return ApiResponse.created(storeService.createStore(storeCreateRequestDto));
+  }
+
+
+}

--- a/src/main/java/com/baedalping/delivery/store/StoreCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/store/StoreCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.baedalping.delivery.store;
 
+import jakarta.validation.constraints.NotBlank;
 import java.time.LocalTime;
 import java.util.UUID;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 public class StoreCreateRequestDto {
+  @NotBlank(message = "상호명을 입력해주세요.")
   private String storeName;
   private String storePhone;
   private String storeAddress;

--- a/src/main/java/com/baedalping/delivery/store/StoreCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/store/StoreCreateRequestDto.java
@@ -1,0 +1,20 @@
+package com.baedalping.delivery.store;
+
+import java.time.LocalTime;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+public class StoreCreateRequestDto {
+  private String storeName;
+  private String storePhone;
+  private String storeAddress;
+  private String storeDetail;
+  private LocalTime openTime;
+  private LocalTime closeTime;
+  private UUID storeCategoryId;
+}

--- a/src/main/java/com/baedalping/delivery/store/StoreCreateResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/store/StoreCreateResponseDto.java
@@ -1,0 +1,31 @@
+package com.baedalping.delivery.store;
+
+import java.time.LocalTime;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StoreCreateResponseDto {
+  private UUID storeId;
+  private String storeName;
+  private String storePhone;
+  private String storeAddress;
+  private String storeDetail;
+  private LocalTime openTime;
+  private LocalTime closeTime;
+  private UUID storeCategoryId;
+
+
+  public StoreCreateResponseDto(Store store){
+    this.storeId = store.getStoreId();
+    this.storeName = store.getStoreName();
+    this.storePhone = store.getStorePhone();
+    this.storeAddress = store.getStoreAddress();
+    this.storeDetail = store.getStoreDetail();
+    this.openTime = store.getOpenTime();
+    this.closeTime = store.getCloseTime();
+    this.storeCategoryId = store.getStoreCategory().getStoreCategoryId();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/store/StoreService.java
+++ b/src/main/java/com/baedalping/delivery/store/StoreService.java
@@ -1,0 +1,33 @@
+package com.baedalping.delivery.store;
+
+
+import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
+import com.baedalping.delivery.global.common.exception.ErrorCode;
+import com.baedalping.delivery.storeCategory.StoreCategory;
+import com.baedalping.delivery.storeCategory.StoreCategoryRepository;
+import jakarta.transaction.Transactional;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class StoreService {
+  private final StoreRepository storeRepository;
+  private final StoreCategoryRepository storeCategoryRepository;
+
+  @Transactional
+  public StoreCreateResponseDto createStore(StoreCreateRequestDto storeCreateRequestDto) {
+    UUID storeCategoryId = storeCreateRequestDto.getStoreCategoryId();
+    StoreCategory storeCategory = storeCategoryRepository.findById(storeCategoryId).orElseThrow(
+        () -> new DeliveryApplicationException(ErrorCode.NOT_FOUND_STORE_CATEGORY)
+    );
+
+    Store store =  storeRepository.save(new Store(storeCreateRequestDto, storeCategory));
+    return new StoreCreateResponseDto(store);
+  }
+
+
+
+
+}

--- a/src/main/java/com/baedalping/delivery/storeCategory/StoreCategory.java
+++ b/src/main/java/com/baedalping/delivery/storeCategory/StoreCategory.java
@@ -1,12 +1,16 @@
 package com.baedalping.delivery.storeCategory;
 
 import com.baedalping.delivery.global.common.AuditField;
+import com.baedalping.delivery.store.Store;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,9 +25,15 @@ public class StoreCategory extends AuditField {
   @Column(name = "store_category_id")
   private UUID storeCategoryId;
 
-  @Column(nullable = false)
+  @Column(nullable = false, unique = true)
   private String storeCategoryName;
+
+  @OneToMany(mappedBy = "storeCategory")
+  private List<Store> storeList = new ArrayList<>();
 
   private boolean isPublic = true;
 
+  public StoreCategory(StoreCategoryCreateRequestDto storeCategoryCreateRequestDto){
+    this.storeCategoryName = storeCategoryCreateRequestDto.getStoreCategoryName();
+  }
 }

--- a/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryController.java
+++ b/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryController.java
@@ -1,0 +1,22 @@
+package com.baedalping.delivery.storeCategory;
+
+import com.baedalping.delivery.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/storeCategories")
+@RequiredArgsConstructor
+@RestController
+public class StoreCategoryController {
+
+  private final StoreCategoryService storeCategoryService;
+
+  @PostMapping
+  public ApiResponse<StoreCategoryCreateResponseDto> createStoreCategory(@RequestBody StoreCategoryCreateRequestDto storeCategoryCreateRequestDto){
+    return ApiResponse.created(storeCategoryService.createStoreCategory(storeCategoryCreateRequestDto));
+  }
+
+}

--- a/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryCreateRequestDto.java
@@ -1,0 +1,13 @@
+package com.baedalping.delivery.storeCategory;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class StoreCategoryCreateRequestDto {
+  private String storeCategoryName;
+}

--- a/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.baedalping.delivery.storeCategory;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,5 +10,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class StoreCategoryCreateRequestDto {
+  @NotBlank(message = "상품 분류명을 입력해주세요.")
   private String storeCategoryName;
 }

--- a/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryCreateResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryCreateResponseDto.java
@@ -1,0 +1,17 @@
+package com.baedalping.delivery.storeCategory;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StoreCategoryCreateResponseDto {
+  private UUID storeCategoryId;
+  private String storeCategoryName;
+
+  public StoreCategoryCreateResponseDto(StoreCategory storeCategory){
+    this.storeCategoryId = storeCategory.getStoreCategoryId();
+    this.storeCategoryName = storeCategory.getStoreCategoryName();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryRepository.java
+++ b/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryRepository.java
@@ -1,7 +1,9 @@
 package com.baedalping.delivery.storeCategory;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UUID> {
+  Optional<StoreCategory> findByStoreCategoryName(String storeCategoryName);
 }

--- a/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryService.java
+++ b/src/main/java/com/baedalping/delivery/storeCategory/StoreCategoryService.java
@@ -1,0 +1,25 @@
+package com.baedalping.delivery.storeCategory;
+
+import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
+import com.baedalping.delivery.global.common.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@AllArgsConstructor
+@Service
+public class StoreCategoryService {
+
+  private final StoreCategoryRepository storeCategoryRepository;
+
+  @Transactional
+  public StoreCategoryCreateResponseDto createStoreCategory(StoreCategoryCreateRequestDto storeCategoryCreateRequestDto) {
+    String storeCategoryName = storeCategoryCreateRequestDto.getStoreCategoryName();
+    if(storeCategoryRepository.findByStoreCategoryName(storeCategoryName).isPresent()) {
+      new DeliveryApplicationException(ErrorCode.DUPLICATE_STORE_CATEGORY_NAME);
+    }
+    
+    StoreCategory storeCategory = storeCategoryRepository.save(new StoreCategory(storeCategoryCreateRequestDto));
+    return new StoreCategoryCreateResponseDto(storeCategory);
+  }
+}


### PR DESCRIPTION
fix: 연관관계 수정 (#3)
- product와 productCategory, store와 storeCategory의 @OneToOne 단방향을 @ManyToOne과 @OneToMany 양방향으로 수정
- LocalTime 데이터타입 수정

feet: 상품 생성 (#3)
- 상품 생성을 위한 가게, 가게 분류, 상품 분류 생성

가게 분류 생성
![storeCategory 생성](https://github.com/user-attachments/assets/4b02a281-c30f-4657-9a85-845dba596c2e)

가게 생성
![store 생성](https://github.com/user-attachments/assets/7f0591d3-42a2-48b0-83ee-db04a7c004f4)

상품 분류 생성
![상품분류 생성](https://github.com/user-attachments/assets/49966b81-6951-464a-84f2-750b000bc850)

상품 생성
![상품 생성](https://github.com/user-attachments/assets/9dcc8ec7-d0ff-43bc-9a35-2319a8968b4e)

