### PR TITLE
유저 조회 및 탈퇴 API 구현 (#13)

### DIFF
--- a/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import com.baedalping.delivery.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -30,6 +31,12 @@ public class UserController {
         userService.create(requestDto.username(), requestDto.password(), requestDto.email()));
   }
 
+  @GetMapping("/{userId}")
+  public ApiResponse<UserReadResponseDto> read(@PathVariable("userId") Long userId) {
+    // TODO :: spring security 적용 이후 principle에 있는 userId를 가져올 예정
+    return ApiResponse.ok(userService.get(userId));
+  }
+
   @PutMapping
   public ApiResponse<UserUpdateResponseDto> update(
       @RequestBody @Validated UserUpdateRequestDto requestDto) {
@@ -40,7 +47,7 @@ public class UserController {
   }
 
   @DeleteMapping("/{userId}")
-  public ApiResponse<UserReadResponseDto> delete(@PathVariable("userId") Long userId){
+  public ApiResponse<UserReadResponseDto> delete(@PathVariable("userId") Long userId) {
     // TODO :: spring security 적용 이후 principle에 있는 userId를 가져올 예정
     return ApiResponse.ok(userService.delete(userId));
   }

--- a/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
@@ -2,12 +2,15 @@ package com.baedalping.delivery.domain.user.controller;
 
 import com.baedalping.delivery.domain.user.dto.UserCreateRequestDto;
 import com.baedalping.delivery.domain.user.dto.UserCreateResponseDto;
+import com.baedalping.delivery.domain.user.dto.UserReadResponseDto;
 import com.baedalping.delivery.domain.user.dto.UserUpdateRequestDto;
 import com.baedalping.delivery.domain.user.dto.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.service.UserService;
 import com.baedalping.delivery.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,5 +37,11 @@ public class UserController {
     return ApiResponse.ok(
         userService.updateUserInfo(
             userId, requestDto.username(), requestDto.password(), requestDto.email()));
+  }
+
+  @DeleteMapping("/{userId}")
+  public ApiResponse<UserReadResponseDto> delete(@PathVariable("userId") Long userId){
+    // TODO :: spring security 적용 이후 principle에 있는 userId를 가져올 예정
+    return ApiResponse.ok(userService.delete(userId));
   }
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/UserReadResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/UserReadResponseDto.java
@@ -1,0 +1,65 @@
+package com.baedalping.delivery.domain.user.dto;
+
+import com.baedalping.delivery.domain.user.entity.User;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class UserReadResponseDto{
+  private Long userId;
+  private String userName;
+  private String email;
+  private String userRole;
+  private boolean isPublic;
+  private LocalDateTime createdAt;
+  private String createBy;
+  private LocalDateTime updatedAt;
+  private String updatedBy;
+  private LocalDateTime deletedAt;
+  private String deletedBy;
+
+  @Builder
+  private UserReadResponseDto(
+      Long userId,
+      String userName,
+      String email,
+      String userRole,
+      boolean isPublic,
+      LocalDateTime createdAt,
+      String createBy,
+      LocalDateTime updatedAt,
+      String updatedBy,
+      LocalDateTime deletedAt,
+      String deletedBy) {
+    this.userId = userId;
+    this.userName = userName;
+    this.email = email;
+    this.userRole = userRole;
+    this.isPublic = isPublic;
+    this.createdAt = createdAt;
+    this.createBy = createBy;
+    this.updatedAt = updatedAt;
+    this.updatedBy = updatedBy;
+    this.deletedAt = deletedAt;
+    this.deletedBy = deletedBy;
+  }
+
+  public static UserReadResponseDto ofEntity(User user) {
+    return UserReadResponseDto.builder()
+        .userId(user.getUserId())
+        .userName(user.getUsername())
+        .email(user.getEmail())
+        .userRole(user.getRole().getRoleName())
+        .isPublic(user.isPublic())
+        .createdAt(user.getCreatedAt())
+        .createBy(user.getCreatedBy())
+        .updatedAt(user.getUpdatedAt())
+        .updatedBy(user.getUpdatedBy())
+        .deletedAt(user.getDeletedAt())
+        .deletedBy(user.getDeletedBy())
+        .build();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/User.java
@@ -18,12 +18,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "P_USERS")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("deleted_at is NULL")
+@SQLDelete(sql = "UPDATE p_users SET deleted_at = NOW() where user_id = ?")
 @Getter
 public class User extends AuditField {
   @Id

--- a/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
@@ -29,6 +29,10 @@ public class UserService {
     return UserCreateResponseDto.ofEntity(userRepository.save(newUser));
   }
 
+  public UserReadResponseDto get(Long userId) {
+    return UserReadResponseDto.ofEntity(findByUser(userId));
+  }
+
   @Transactional
   public UserUpdateResponseDto updateUserInfo(
       Long userId, String username, String password, String email) {
@@ -40,7 +44,7 @@ public class UserService {
   }
 
   @Transactional
-  public UserReadResponseDto delete(Long userId){
+  public UserReadResponseDto delete(Long userId) {
     User user = findByUser(userId);
     user.setInvisible();
     userRepository.delete(user);
@@ -48,7 +52,7 @@ public class UserService {
     return UserReadResponseDto.ofEntity(user);
   }
 
-  private User findByUser(Long userId){
+  private User findByUser(Long userId) {
     return userRepository
         .findByUserId(userId)
         .orElseThrow(() -> new DeliveryApplicationException(ErrorCode.NOT_FOUND_USER));

--- a/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
@@ -1,12 +1,14 @@
 package com.baedalping.delivery.domain.user.service;
 
 import com.baedalping.delivery.domain.user.dto.UserCreateResponseDto;
+import com.baedalping.delivery.domain.user.dto.UserReadResponseDto;
 import com.baedalping.delivery.domain.user.dto.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.entity.User;
 import com.baedalping.delivery.domain.user.repository.UserRepository;
 import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
 import com.baedalping.delivery.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class UserService {
   private final UserRepository userRepository;
   private final BCryptPasswordEncoder encoder;
@@ -29,15 +32,26 @@ public class UserService {
   @Transactional
   public UserUpdateResponseDto updateUserInfo(
       Long userId, String username, String password, String email) {
-    User user =
-        userRepository
-            .findByUserId(userId)
-            .orElseThrow(() -> new DeliveryApplicationException(ErrorCode.NOT_FOUND_USER));
-
+    User user = findByUser(userId);
     user.updateInfo(username, encoder.encode(password), email);
     userRepository.saveAndFlush(user);
 
     return UserUpdateResponseDto.ofEntity(user);
+  }
+
+  @Transactional
+  public UserReadResponseDto delete(Long userId){
+    User user = findByUser(userId);
+    user.setInvisible();
+    userRepository.delete(user);
+    userRepository.flush();
+    return UserReadResponseDto.ofEntity(user);
+  }
+
+  private User findByUser(Long userId){
+    return userRepository
+        .findByUserId(userId)
+        .orElseThrow(() -> new DeliveryApplicationException(ErrorCode.NOT_FOUND_USER));
   }
 
   private void validateUniqueEmail(String email) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,3 +17,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+logging:
+  level:
+    org.springframework.security: DEBUG

--- a/src/test/java/com/baedalping/delivery/user/UserFixture.java
+++ b/src/test/java/com/baedalping/delivery/user/UserFixture.java
@@ -1,0 +1,13 @@
+package com.baedalping.delivery.user;
+
+import com.baedalping.delivery.domain.user.entity.User;
+
+public class UserFixture {
+  public static User get(String username, String password, String email){
+    return User.builder()
+        .username(username)
+        .password(password)
+        .email(email)
+        .build();
+  }
+}

--- a/src/test/java/com/baedalping/delivery/user/UserServiceTest.java
+++ b/src/test/java/com/baedalping/delivery/user/UserServiceTest.java
@@ -5,12 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import com.baedalping.delivery.domain.user.dto.UserReadResponseDto;
 import com.baedalping.delivery.domain.user.dto.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.entity.User;
 import com.baedalping.delivery.domain.user.repository.UserRepository;
 import com.baedalping.delivery.domain.user.service.UserService;
 import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -25,17 +27,28 @@ public class UserServiceTest {
   @Mock private BCryptPasswordEncoder encoder;
   @InjectMocks private UserService userService;
 
+  private String username;
+  private String password;
+  private String email;
+  private Long userId;
+  private User mockUser;
+
+  @BeforeEach
+  void setUp() {
+    username = "username";
+    password = "pass123***";
+    email = "test@test.com";
+    userId = 1L;
+    mockUser = UserFixture.get(username, password, email);
+  }
+
   @Test
   void 이메일이_중복되어_회원가입에_실패한다() {
-    String username = "username";
-    String password = "pass123***";
-    String duplicatedEmail = "test@test.com";
-
-    when(userRepository.existsByEmail(duplicatedEmail)).thenReturn(Boolean.TRUE);
+    when(userRepository.existsByEmail(email)).thenReturn(Boolean.TRUE);
     DeliveryApplicationException exception =
         assertThrows(
             DeliveryApplicationException.class,
-            () -> userService.create(username, password, duplicatedEmail));
+            () -> userService.create(username, password, email));
 
     assertEquals(exception.getErrorCode().getStatus(), HttpStatus.CONFLICT);
     assertEquals(exception.getErrorCode().getMessage(), "이미 가입된 유저 이메일 입니다");
@@ -43,29 +56,32 @@ public class UserServiceTest {
 
   @Test
   void 유저정보_업데이트에_성공한다() {
-    Long userId = 1L;
-    String username = "updatename";
-    String password = "newpass123@@";
-    String email = "test@test.com";
-    User user = User.builder().email(email).password(password).email(email).build();
-    when(userRepository.findByUserId(userId)).thenReturn(Optional.of(user));
+    username = "updatename";
+    password = "newpass123@@";
+
+    when(userRepository.findByUserId(userId)).thenReturn(Optional.of(mockUser));
     UserUpdateResponseDto response = userService.updateUserInfo(userId, username, password, email);
+
     assertThat(response.getUserName()).isEqualTo(username);
   }
 
   @Test
   void 유저정보_업데이트시_유저정보를_찾을수없어_실패한다() {
-    Long userId = 1L;
-    String username = "username";
-    String password = "pass123***";
-    String email = "test@test.com";
-
     when(userRepository.findByUserId(userId)).thenReturn(Optional.empty());
     DeliveryApplicationException exception =
         assertThrows(
             DeliveryApplicationException.class,
             () -> userService.updateUserInfo(userId, username, password, email));
+
     assertEquals(exception.getErrorCode().getStatus(), HttpStatus.NOT_FOUND);
     assertEquals(exception.getErrorCode().getMessage(), "가입된 유저가 아닙니다");
+  }
+
+  @Test
+  void 유저탈퇴시_퍼블릭여부를_트루값으로_변경한다() {
+    when(userRepository.findByUserId(userId)).thenReturn(Optional.of(mockUser));
+    UserReadResponseDto response = userService.delete(userId);
+
+    assertThat(response.isPublic()).isFalse();
   }
 }


### PR DESCRIPTION
- issue #13 
- 유저 탈퇴 시 userId를 필터에서 넣은 UserDetailDto에서 가져올 예정 (현재는 PathVariable로 처리)
- 유저 탈퇴 시 deleted_at에 현재 timestamp, is_public을 false로 업데이트 
- 유저 엔티티에 조회 발생 시 deleted_at이 null인것만 조회될 수 있도록 설정
- 테스트 추가
![스크린샷 2024-08-28 오후 12 54 18](https://github.com/user-attachments/assets/d99c2f17-6a1e-4f06-83cd-0f6e418f7f61)
![image](https://github.com/user-attachments/assets/ff445111-838f-4908-b69f-7c995c96eaaa)
<img width="437" alt="스크린샷 2024-08-28 오후 12 49 14" src="https://github.com/user-attachments/assets/a243bf89-8898-47a3-bf38-3287dd276080">