### PR TITLE
feat: 주문서 조회 구현 (#18)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,14 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.mapstruct:mapstruct:1.6.0'
+    implementation 'org.mapstruct:mapstruct-processor:1.6.0'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.0'
+    implementation 'org.modelmapper:modelmapper:3.2.1'
+
+
+
+
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/baedalping/delivery/domain/order/controller/OrderController.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/controller/OrderController.java
@@ -2,14 +2,20 @@ package com.baedalping.delivery.domain.order.controller;
 
 import com.baedalping.delivery.domain.order.dto.OrderCreateRequestDto;
 import com.baedalping.delivery.domain.order.dto.OrderCreateResponseDto;
+import com.baedalping.delivery.domain.order.dto.OrderGetResponseDto;
+import com.baedalping.delivery.domain.order.entity.Order;
 import com.baedalping.delivery.domain.order.service.OrderService;
 import com.baedalping.delivery.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,9 +25,6 @@ public class OrderController {
 
     private final OrderService orderService;
 
-    /*
-    TODO: body로 받아오고 있는 주문 상세 내역을 Redis에서 가져오도록 변경할 것
-     */
     @PostMapping
     public ApiResponse<OrderCreateResponseDto> createOrder(
         @RequestBody @Valid OrderCreateRequestDto orderRequest) {
@@ -30,16 +33,31 @@ public class OrderController {
     }
 
     // 가게 주문 조회
-//    @GetMapping("/store/{storeId}")
-//    public List<Order> getOrdersByStore(@PathVariable UUID storeId) {
-//        return orderService.getOrdersByStoreId(storeId);
-//    }
-//
-//    // 개인 주문 조회
-//    @GetMapping("/user/{userId}")
-//    public List<Order> getOrdersByUser(@PathVariable Long userId) {
-//        return orderService.getOrdersByUserId(userId);
-//    }
+    @GetMapping("/store/{storeId}")
+    public List<OrderGetResponseDto> getOrdersByStore(
+        @PathVariable UUID storeId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        return orderService.getOrdersByStoreId(storeId, page, size);
+    }
+
+    // 개인 주문 조회
+    @GetMapping("/user/{userId}")
+    public List<OrderGetResponseDto> getOrdersByUser(
+        @PathVariable Long userId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        return orderService.getOrdersByUserId(userId, page, size);
+
+    }
+
+    // 주문 단건 상세 조회
+    @GetMapping("/{orderId}")
+    public OrderGetResponseDto getOrderById(@PathVariable UUID orderId) {
+       return orderService.getOrderById(orderId);
+    }
 //
 //    // 주문 키워드 검색
 //    @GetMapping("/search")
@@ -47,11 +65,6 @@ public class OrderController {
 //        return orderService.searchOrders(keyword);
 //    }
 //
-//    // 주문 단건 상세 조회
-//    @GetMapping("/{orderId}")
-//    public Order getOrderById(@PathVariable UUID orderId) {
-//        return orderService.getOrderById(orderId);
-//    }
 //
 //    // 주문 취소
 //    @PostMapping("/{orderId}/cancel")

--- a/src/main/java/com/baedalping/delivery/domain/order/controller/OrderController.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/controller/OrderController.java
@@ -3,13 +3,12 @@ package com.baedalping.delivery.domain.order.controller;
 import com.baedalping.delivery.domain.order.dto.OrderCreateRequestDto;
 import com.baedalping.delivery.domain.order.dto.OrderCreateResponseDto;
 import com.baedalping.delivery.domain.order.dto.OrderGetResponseDto;
-import com.baedalping.delivery.domain.order.entity.Order;
 import com.baedalping.delivery.domain.order.service.OrderService;
 import com.baedalping.delivery.global.common.ApiResponse;
 import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,29 +33,37 @@ public class OrderController {
 
     // 가게 주문 조회
     @GetMapping("/store/{storeId}")
-    public List<OrderGetResponseDto> getOrdersByStore(
+    public ApiResponse<Page<OrderGetResponseDto>> getOrdersByStore(
         @PathVariable UUID storeId,
         @RequestParam(defaultValue = "0") int page,
-        @RequestParam(defaultValue = "10") int size
+        @RequestParam(defaultValue = "10") int size,
+        @RequestParam(defaultValue = "asc") String sortDirection
     ) {
-        return orderService.getOrdersByStoreId(storeId, page, size);
+        return ApiResponse.ok(
+            orderService.getOrdersByStoreId(storeId, page, size, sortDirection)
+        );
     }
 
     // 개인 주문 조회
     @GetMapping("/user/{userId}")
-    public List<OrderGetResponseDto> getOrdersByUser(
+    public ApiResponse<Page<OrderGetResponseDto>> getOrdersByUser(
         @PathVariable Long userId,
         @RequestParam(defaultValue = "0") int page,
-        @RequestParam(defaultValue = "10") int size
-    ) {
-        return orderService.getOrdersByUserId(userId, page, size);
+        @RequestParam(defaultValue = "10") int size,
+        @RequestParam(defaultValue = "asc") String sortDirection
 
+    ) {
+        return ApiResponse.ok(
+            orderService.getOrdersByUserId(userId, page, size, sortDirection)
+        );
     }
 
     // 주문 단건 상세 조회
     @GetMapping("/{orderId}")
-    public OrderGetResponseDto getOrderById(@PathVariable UUID orderId) {
-       return orderService.getOrderById(orderId);
+    public ApiResponse<OrderGetResponseDto> getOrderById(@PathVariable UUID orderId) {
+        return ApiResponse.ok(
+            orderService.getOrderById(orderId)
+        );
     }
 //
 //    // 주문 키워드 검색

--- a/src/main/java/com/baedalping/delivery/domain/order/dto/OrderDetailResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/dto/OrderDetailResponseDto.java
@@ -4,6 +4,7 @@ package com.baedalping.delivery.domain.order.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.UUID;
@@ -11,6 +12,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @AllArgsConstructor
+@NoArgsConstructor
 public class OrderDetailResponseDto {
     private UUID orderDetailId;
     private UUID productId;

--- a/src/main/java/com/baedalping/delivery/domain/order/dto/OrderGetResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/dto/OrderGetResponseDto.java
@@ -1,17 +1,18 @@
 package com.baedalping.delivery.domain.order.dto;
 
-
-
 import com.baedalping.delivery.domain.order.entity.OrderStatus;
-import lombok.Getter;
-import lombok.Setter;
-
 import java.util.List;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
-public class OrderCreateResponseDto {
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderGetResponseDto {
     private UUID orderId;
     private Long userId;
     private UUID storeId;
@@ -22,9 +23,4 @@ public class OrderCreateResponseDto {
     private Boolean isPublic;
     private List<OrderDetailResponseDto> orderDetails;
 
-    public OrderCreateResponseDto setOrderDetails(List<OrderDetailResponseDto> orderDetails) {
-        this.orderDetails = orderDetails;
-        return this; // 'this'를 반환하여 메서드 체이닝이 가능하도록 수정
-    }
 }
-

--- a/src/main/java/com/baedalping/delivery/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/repository/OrderRepository.java
@@ -1,11 +1,17 @@
 package com.baedalping.delivery.domain.order.repository;
 
 import com.baedalping.delivery.domain.order.entity.Order;
+import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, UUID> {
 
+    Page<Order> findByStoreIdAndIsPublicTrue(UUID storeId, Pageable pageable);
+
+    Page<Order> findByUserIdAndIsPublicTrue(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/baedalping/delivery/domain/order/service/OrderMapperService.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/service/OrderMapperService.java
@@ -1,0 +1,26 @@
+package com.baedalping.delivery.domain.order.service;
+
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class OrderMapperService {
+
+    private final ModelMapper modelMapper;
+
+    public <S, T> T convert(S source, Class<T> targetClass) {
+        return modelMapper.map(source, targetClass);
+    }
+
+    public <S, T> List<T> convertList(List<S> sourceList, Class<T> targetClass) {
+        return sourceList.stream()
+            .map(source -> modelMapper.map(source, targetClass))
+            .collect(Collectors.toList());
+    }
+}
+

--- a/src/main/java/com/baedalping/delivery/domain/order/service/OrderMapperService.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/service/OrderMapperService.java
@@ -2,6 +2,7 @@ package com.baedalping.delivery.domain.order.service;
 
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,6 +22,10 @@ public class OrderMapperService {
         return sourceList.stream()
             .map(source -> modelMapper.map(source, targetClass))
             .collect(Collectors.toList());
+    }
+
+    public <S, T> Page<T> convertPage(Page<S> sourcePage, Class<T> targetClass) {
+        return sourcePage.map(source -> modelMapper.map(source, targetClass));
     }
 }
 

--- a/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
   NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
-  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
   DUPLICATED_USER(HttpStatus.CONFLICT, "이미 가입된 유저 이메일 입니다"),
 
   NOT_FOUND_STORE_CATEGORY(HttpStatus.NOT_FOUND, "가게 분류를 찾을 수 없습니다."),
@@ -21,7 +20,10 @@ public enum ErrorCode {
 
   // Cart
   CART_ONLY_ONE_STORE_ALLOWED(HttpStatus.BAD_REQUEST, "한 번에 하나의 가게의 상품만 담을 수 있습니다."),
-  NOT_FOUND_PRODUCT_IN_CART(HttpStatus.NOT_FOUND, "장바구니에 해당 상품이 존재하지 않습니다.")
+  NOT_FOUND_PRODUCT_IN_CART(HttpStatus.NOT_FOUND, "장바구니에 해당 상품이 존재하지 않습니다."),
+
+  // Order
+  NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다.")
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/baedalping/delivery/global/config/MapperConfig.java
+++ b/src/main/java/com/baedalping/delivery/global/config/MapperConfig.java
@@ -1,0 +1,13 @@
+package com.baedalping.delivery.global.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MapperConfig {
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+}


### PR DESCRIPTION
- dto 변환을 위한 Mapper 생성
- 가게 ID를 통한 주문 조회 구현
- 유저 ID를 통한 주문 조회 구현
- 주문 상세 조회 구현
- 조회 페이징 처리

기타사항
id를 통한 검증의 경우 다른 도메인과의 연동 후 구현
리턴값에 대한 세부적인 조정은 추후 조정(현재는 모든 내용 상세 조회 적용)
findbyid등 추후 추가 메소드 정리
