### PR TITLE
유저주소 등록 수정 조회 API 구현(#14)

### DIFF
--- a/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
@@ -1,10 +1,12 @@
 package com.baedalping.delivery.domain.user.controller;
 
-import com.baedalping.delivery.domain.user.dto.UserCreateRequestDto;
-import com.baedalping.delivery.domain.user.dto.UserCreateResponseDto;
-import com.baedalping.delivery.domain.user.dto.UserReadResponseDto;
-import com.baedalping.delivery.domain.user.dto.UserUpdateRequestDto;
-import com.baedalping.delivery.domain.user.dto.UserUpdateResponseDto;
+import com.baedalping.delivery.domain.user.dto.request.UserAddressCreateRequestDto;
+import com.baedalping.delivery.domain.user.dto.request.UserCreateRequestDto;
+import com.baedalping.delivery.domain.user.dto.response.UserAddressResponseDto;
+import com.baedalping.delivery.domain.user.dto.response.UserCreateResponseDto;
+import com.baedalping.delivery.domain.user.dto.response.UserReadResponseDto;
+import com.baedalping.delivery.domain.user.dto.request.UserUpdateRequestDto;
+import com.baedalping.delivery.domain.user.dto.response.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.service.UserService;
 import com.baedalping.delivery.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -50,5 +52,14 @@ public class UserController {
   public ApiResponse<UserReadResponseDto> delete(@PathVariable("userId") Long userId) {
     // TODO :: spring security 적용 이후 principle에 있는 userId를 가져올 예정
     return ApiResponse.ok(userService.delete(userId));
+  }
+
+  @PostMapping("/address/{userId}")
+  public ApiResponse<UserAddressResponseDto> createAddress(
+      @PathVariable("userId") Long userId,
+      @RequestBody @Validated UserAddressCreateRequestDto requestDto) {
+    return ApiResponse.ok(
+        userService.addAddress(
+            userId, requestDto.address(), requestDto.zipcode(), requestDto.alias()));
   }
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
@@ -9,6 +9,7 @@ import com.baedalping.delivery.domain.user.dto.request.UserUpdateRequestDto;
 import com.baedalping.delivery.domain.user.dto.response.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.service.UserService;
 import com.baedalping.delivery.global.common.ApiResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -34,7 +35,7 @@ public class UserController {
   }
 
   @GetMapping("/{userId}")
-  public ApiResponse<UserReadResponseDto> read(@PathVariable("userId") Long userId) {
+  public ApiResponse<UserReadResponseDto> get(@PathVariable("userId") Long userId) {
     // TODO :: spring security 적용 이후 principle에 있는 userId를 가져올 예정
     return ApiResponse.ok(userService.get(userId));
   }
@@ -58,8 +59,15 @@ public class UserController {
   public ApiResponse<UserAddressResponseDto> createAddress(
       @PathVariable("userId") Long userId,
       @RequestBody @Validated UserAddressCreateRequestDto requestDto) {
+    // TODO :: spring security 적용 이후 principle에 있는 userId를 가져올 예정
     return ApiResponse.ok(
         userService.addAddress(
             userId, requestDto.address(), requestDto.zipcode(), requestDto.alias()));
+  }
+
+  @GetMapping("/address/{userId}")
+  public ApiResponse<List<UserAddressResponseDto>> getAddressList(@PathVariable("userId") Long userId) {
+    // TODO :: spring security 적용 이후 principle에 있는 userId를 가져올 예정
+    return ApiResponse.ok(userService.getAddressList(userId));
   }
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.baedalping.delivery.domain.user.controller;
 
 import com.baedalping.delivery.domain.user.dto.request.UserAddressCreateRequestDto;
+import com.baedalping.delivery.domain.user.dto.request.UserAddressUpdateRequestDto;
 import com.baedalping.delivery.domain.user.dto.request.UserCreateRequestDto;
 import com.baedalping.delivery.domain.user.dto.request.UserUpdateRequestDto;
 import com.baedalping.delivery.domain.user.dto.response.UserAddressResponseDto;
@@ -10,6 +11,7 @@ import com.baedalping.delivery.domain.user.dto.response.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.service.UserService;
 import com.baedalping.delivery.global.common.ApiResponse;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -60,14 +62,26 @@ public class UserController {
       @PathVariable("userId") Long userId,
       @RequestBody @Validated UserAddressCreateRequestDto requestDto) {
     // TODO :: spring security 적용 이후 principle에 있는 userId를 가져올 예정
-    return ApiResponse.ok(
+    return ApiResponse.created(
         userService.addAddress(
             userId, requestDto.address(), requestDto.zipcode(), requestDto.alias()));
   }
 
   @GetMapping("/address/{userId}")
-  public ApiResponse<List<UserAddressResponseDto>> getAddressList(@PathVariable("userId") Long userId) {
+  public ApiResponse<List<UserAddressResponseDto>> getAddressList(
+      @PathVariable("userId") Long userId) {
     // TODO :: spring security 적용 이후 principle에 있는 userId를 가져올 예정
     return ApiResponse.ok(userService.getAddressList(userId));
+  }
+
+  @PutMapping("/address/{addressId}/{userId}")
+  public ApiResponse<UserAddressResponseDto> updateAddress(
+      // TODO :: spring security 적용 이후 principle에 있는 userId를 가져올 예정
+      @PathVariable("addressId") UUID addressId,
+      @PathVariable("userId") Long userId,
+      @RequestBody @Validated UserAddressUpdateRequestDto requestDto) {
+    return ApiResponse.ok(
+        userService.updateAddress(
+            addressId, userId, requestDto.address(), requestDto.zipcode(), requestDto.alias()));
   }
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
@@ -2,10 +2,10 @@ package com.baedalping.delivery.domain.user.controller;
 
 import com.baedalping.delivery.domain.user.dto.request.UserAddressCreateRequestDto;
 import com.baedalping.delivery.domain.user.dto.request.UserCreateRequestDto;
+import com.baedalping.delivery.domain.user.dto.request.UserUpdateRequestDto;
 import com.baedalping.delivery.domain.user.dto.response.UserAddressResponseDto;
 import com.baedalping.delivery.domain.user.dto.response.UserCreateResponseDto;
 import com.baedalping.delivery.domain.user.dto.response.UserReadResponseDto;
-import com.baedalping.delivery.domain.user.dto.request.UserUpdateRequestDto;
 import com.baedalping.delivery.domain.user.dto.response.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.service.UserService;
 import com.baedalping.delivery.global.common.ApiResponse;

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/request/UserAddressCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/request/UserAddressCreateRequestDto.java
@@ -1,0 +1,11 @@
+package com.baedalping.delivery.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UserAddressCreateRequestDto(
+    @NotBlank(message = "주소는 필수값 입니다") String address,
+    @NotBlank(message = "우편번호는 필수값 입니다")
+        @Pattern(regexp = "^\\d{5}$", message = "우편번호는 5자리 숫자여야 합니다")
+        String zipcode,
+    String alias) {}

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/request/UserAddressUpdateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/request/UserAddressUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package com.baedalping.delivery.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UserAddressUpdateRequestDto(
+    @NotBlank(message = "주소는 필수값 입니다") String address,
+    @NotBlank(message = "우편번호는 필수값 입니다")
+        @Pattern(regexp = "^\\d{5}$", message = "우편번호는 5자리 숫자여야 합니다")
+        String zipcode,
+    String alias) {}

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/request/UserCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/request/UserCreateRequestDto.java
@@ -1,10 +1,10 @@
-package com.baedalping.delivery.domain.user.dto;
+package com.baedalping.delivery.domain.user.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
-public record UserUpdateRequestDto(
+public record UserCreateRequestDto(
     @NotBlank(message = "유저이름은 필수값 입니다")
         @Pattern(
             regexp = "^[a-z0-9]{4,10}$",

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/request/UserUpdateRequestDto.java
@@ -1,10 +1,10 @@
-package com.baedalping.delivery.domain.user.dto;
+package com.baedalping.delivery.domain.user.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
-public record UserCreateRequestDto(
+public record UserUpdateRequestDto(
     @NotBlank(message = "유저이름은 필수값 입니다")
         @Pattern(
             regexp = "^[a-z0-9]{4,10}$",

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserAddressResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserAddressResponseDto.java
@@ -1,0 +1,32 @@
+package com.baedalping.delivery.domain.user.dto.response;
+
+import com.baedalping.delivery.domain.user.entity.UserAddress;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class UserAddressResponseDto {
+  private Long userId;
+  private String address;
+  private String zipcode;
+  private String alias;
+
+  @Builder
+  private UserAddressResponseDto(Long userId, String address, String zipcode, String alias) {
+    this.userId = userId;
+    this.address = address;
+    this.zipcode = zipcode;
+    this.alias = alias;
+  }
+
+  public static UserAddressResponseDto fromEntity(Long userId, UserAddress userAddress) {
+    return UserAddressResponseDto.builder()
+        .userId(userId)
+        .address(userAddress.getAddress())
+        .zipcode(userAddress.getZipcode())
+        .alias(userAddress.getAlias())
+        .build();
+  }
+}

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserAddressResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserAddressResponseDto.java
@@ -8,22 +8,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class UserAddressResponseDto {
-  private Long userId;
   private String address;
   private String zipcode;
   private String alias;
 
   @Builder
-  private UserAddressResponseDto(Long userId, String address, String zipcode, String alias) {
-    this.userId = userId;
+  private UserAddressResponseDto(String address, String zipcode, String alias) {
     this.address = address;
     this.zipcode = zipcode;
     this.alias = alias;
   }
 
-  public static UserAddressResponseDto fromEntity(Long userId, UserAddress userAddress) {
+  public static UserAddressResponseDto fromEntity(UserAddress userAddress) {
     return UserAddressResponseDto.builder()
-        .userId(userId)
         .address(userAddress.getAddress())
         .zipcode(userAddress.getZipcode())
         .alias(userAddress.getAlias())

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserCreateResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserCreateResponseDto.java
@@ -1,4 +1,4 @@
-package com.baedalping.delivery.domain.user.dto;
+package com.baedalping.delivery.domain.user.dto.response;
 
 import com.baedalping.delivery.domain.user.entity.User;
 import java.time.LocalDateTime;
@@ -6,60 +6,48 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
 @Getter
-public class UserReadResponseDto{
+@NoArgsConstructor
+public class UserCreateResponseDto {
   private Long userId;
   private String userName;
   private String email;
   private String userRole;
   private boolean isPublic;
   private LocalDateTime createdAt;
-  private String createBy;
   private LocalDateTime updatedAt;
-  private String updatedBy;
   private LocalDateTime deletedAt;
-  private String deletedBy;
 
   @Builder
-  private UserReadResponseDto(
+  private UserCreateResponseDto(
       Long userId,
       String userName,
       String email,
       String userRole,
       boolean isPublic,
       LocalDateTime createdAt,
-      String createBy,
       LocalDateTime updatedAt,
-      String updatedBy,
-      LocalDateTime deletedAt,
-      String deletedBy) {
+      LocalDateTime deletedAt) {
     this.userId = userId;
     this.userName = userName;
     this.email = email;
     this.userRole = userRole;
     this.isPublic = isPublic;
     this.createdAt = createdAt;
-    this.createBy = createBy;
     this.updatedAt = updatedAt;
-    this.updatedBy = updatedBy;
     this.deletedAt = deletedAt;
-    this.deletedBy = deletedBy;
   }
 
-  public static UserReadResponseDto ofEntity(User user) {
-    return UserReadResponseDto.builder()
+  public static UserCreateResponseDto ofEntity(User user) {
+    return UserCreateResponseDto.builder()
         .userId(user.getUserId())
         .userName(user.getUsername())
         .email(user.getEmail())
         .userRole(user.getRole().getRoleName())
         .isPublic(user.isPublic())
         .createdAt(user.getCreatedAt())
-        .createBy(user.getCreatedBy())
         .updatedAt(user.getUpdatedAt())
-        .updatedBy(user.getUpdatedBy())
         .deletedAt(user.getDeletedAt())
-        .deletedBy(user.getDeletedBy())
         .build();
   }
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserReadResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserReadResponseDto.java
@@ -1,4 +1,4 @@
-package com.baedalping.delivery.domain.user.dto;
+package com.baedalping.delivery.domain.user.dto.response;
 
 import com.baedalping.delivery.domain.user.entity.User;
 import java.time.LocalDateTime;
@@ -6,48 +6,60 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @NoArgsConstructor
-public class UserCreateResponseDto {
+@Getter
+public class UserReadResponseDto{
   private Long userId;
   private String userName;
   private String email;
   private String userRole;
   private boolean isPublic;
   private LocalDateTime createdAt;
+  private String createBy;
   private LocalDateTime updatedAt;
+  private String updatedBy;
   private LocalDateTime deletedAt;
+  private String deletedBy;
 
   @Builder
-  private UserCreateResponseDto(
+  private UserReadResponseDto(
       Long userId,
       String userName,
       String email,
       String userRole,
       boolean isPublic,
       LocalDateTime createdAt,
+      String createBy,
       LocalDateTime updatedAt,
-      LocalDateTime deletedAt) {
+      String updatedBy,
+      LocalDateTime deletedAt,
+      String deletedBy) {
     this.userId = userId;
     this.userName = userName;
     this.email = email;
     this.userRole = userRole;
     this.isPublic = isPublic;
     this.createdAt = createdAt;
+    this.createBy = createBy;
     this.updatedAt = updatedAt;
+    this.updatedBy = updatedBy;
     this.deletedAt = deletedAt;
+    this.deletedBy = deletedBy;
   }
 
-  public static UserCreateResponseDto ofEntity(User user) {
-    return UserCreateResponseDto.builder()
+  public static UserReadResponseDto ofEntity(User user) {
+    return UserReadResponseDto.builder()
         .userId(user.getUserId())
         .userName(user.getUsername())
         .email(user.getEmail())
         .userRole(user.getRole().getRoleName())
         .isPublic(user.isPublic())
         .createdAt(user.getCreatedAt())
+        .createBy(user.getCreatedBy())
         .updatedAt(user.getUpdatedAt())
+        .updatedBy(user.getUpdatedBy())
         .deletedAt(user.getDeletedAt())
+        .deletedBy(user.getDeletedBy())
         .build();
   }
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserReadResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserReadResponseDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Getter
-public class UserReadResponseDto{
+public class UserReadResponseDto {
   private Long userId;
   private String userName;
   private String email;

--- a/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserUpdateResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/dto/response/UserUpdateResponseDto.java
@@ -1,4 +1,4 @@
-package com.baedalping.delivery.domain.user.dto;
+package com.baedalping.delivery.domain.user.dto.response;
 
 import com.baedalping.delivery.domain.user.entity.User;
 import java.time.LocalDateTime;

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
@@ -58,7 +58,7 @@ public class UserAddress extends AuditField {
     this.isPublic = false;
   }
 
-  public void update(String address, String zipcode, String alias){
+  public void update(String address, String zipcode, String alias) {
     this.address = address;
     this.zipcode = zipcode;
     this.alias = alias;

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -30,23 +31,31 @@ public class UserAddress extends AuditField {
   private User user;
 
   @Column(name = "address", nullable = false)
+  @Getter
   private String address;
 
   @Column(name = "zipcode", nullable = false, length = 5)
+  @Getter
   private String zipcode;
 
   @Column(name = "address_alias", nullable = true)
+  @Getter
   private String alias;
 
+  @Column(name = "is_public")
+  private boolean isPublic = true;
+
   @Builder
-  private UserAddress(User user, String address, String zipcode, String alias) {
-    this.user = user;
+  private UserAddress(String address, String zipcode, String alias) {
     this.address = address;
     this.zipcode = zipcode;
     this.alias = alias;
   }
-
-  public void setUser(User user) {
+  public void setUser(User user){
     this.user = user;
+  }
+
+  public void setInvisible(){
+    this.isPublic = false;
   }
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
@@ -20,6 +20,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Entity
 @NoArgsConstructor
 @SQLRestriction("deleted_at is NULL")
+@Getter
 public class UserAddress extends AuditField {
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
@@ -31,15 +32,12 @@ public class UserAddress extends AuditField {
   private User user;
 
   @Column(name = "address", nullable = false)
-  @Getter
   private String address;
 
   @Column(name = "zipcode", nullable = false, length = 5)
-  @Getter
   private String zipcode;
 
   @Column(name = "address_alias", nullable = true)
-  @Getter
   private String alias;
 
   @Column(name = "is_public")
@@ -58,5 +56,11 @@ public class UserAddress extends AuditField {
 
   public void setInvisible() {
     this.isPublic = false;
+  }
+
+  public void update(String address, String zipcode, String alias){
+    this.address = address;
+    this.zipcode = zipcode;
+    this.alias = alias;
   }
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/entity/UserAddress.java
@@ -51,11 +51,12 @@ public class UserAddress extends AuditField {
     this.zipcode = zipcode;
     this.alias = alias;
   }
-  public void setUser(User user){
+
+  public void setUser(User user) {
     this.user = user;
   }
 
-  public void setInvisible(){
+  public void setInvisible() {
     this.isPublic = false;
   }
 }

--- a/src/main/java/com/baedalping/delivery/domain/user/repository/UserAddressRepository.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/repository/UserAddressRepository.java
@@ -1,7 +1,10 @@
 package com.baedalping.delivery.domain.user.repository;
 
 import com.baedalping.delivery.domain.user.entity.UserAddress;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserAddressRepository extends JpaRepository<UserAddress, UUID> {}
+public interface UserAddressRepository extends JpaRepository<UserAddress, UUID> {
+  Optional<UserAddress> findByAddressId(UUID addressId);
+}

--- a/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
@@ -59,22 +59,19 @@ public class UserService {
   }
 
   @Transactional
-  public UserAddressResponseDto addAddress(Long userId, String address, String zipcode, String alias){
+  public UserAddressResponseDto addAddress(
+      Long userId, String address, String zipcode, String alias) {
     User user = findByUser(userId);
-    UserAddress newAddress = UserAddress.builder()
-        .address(address)
-        .zipcode(zipcode)
-        .alias(alias)
-        .build();
+    UserAddress newAddress =
+        UserAddress.builder().address(address).zipcode(zipcode).alias(alias).build();
     user.addAddress(newAddress);
     addressRepository.save(newAddress);
     return UserAddressResponseDto.fromEntity(newAddress);
   }
 
-  public List<UserAddressResponseDto> getAddressList(Long userId){
+  public List<UserAddressResponseDto> getAddressList(Long userId) {
     User user = findByUser(userId);
-    return user.getAddressList()
-        .stream()
+    return user.getAddressList().stream()
         .map(address -> UserAddressResponseDto.fromEntity(address))
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
@@ -1,9 +1,12 @@
 package com.baedalping.delivery.domain.user.service;
 
-import com.baedalping.delivery.domain.user.dto.UserCreateResponseDto;
-import com.baedalping.delivery.domain.user.dto.UserReadResponseDto;
-import com.baedalping.delivery.domain.user.dto.UserUpdateResponseDto;
+import com.baedalping.delivery.domain.user.dto.response.UserAddressResponseDto;
+import com.baedalping.delivery.domain.user.dto.response.UserCreateResponseDto;
+import com.baedalping.delivery.domain.user.dto.response.UserReadResponseDto;
+import com.baedalping.delivery.domain.user.dto.response.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.entity.User;
+import com.baedalping.delivery.domain.user.entity.UserAddress;
+import com.baedalping.delivery.domain.user.repository.UserAddressRepository;
 import com.baedalping.delivery.domain.user.repository.UserRepository;
 import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
 import com.baedalping.delivery.global.common.exception.ErrorCode;
@@ -19,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class UserService {
   private final UserRepository userRepository;
+  private final UserAddressRepository addressRepository;
   private final BCryptPasswordEncoder encoder;
 
   @Transactional
@@ -50,6 +54,20 @@ public class UserService {
     userRepository.delete(user);
     userRepository.flush();
     return UserReadResponseDto.ofEntity(user);
+  }
+
+  @Transactional
+  public UserAddressResponseDto addAddress(Long userId, String address, String zipcode, String alias){
+    User user = findByUser(userId);
+    log.info("{}", user.getUserId());
+    UserAddress newAddress = UserAddress.builder()
+        .address(address)
+        .zipcode(zipcode)
+        .alias(alias)
+        .build();
+    user.addAddress(newAddress);
+    addressRepository.save(newAddress);
+    return UserAddressResponseDto.fromEntity(user.getUserId(), newAddress);
   }
 
   private User findByUser(Long userId) {

--- a/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
@@ -10,6 +10,8 @@ import com.baedalping.delivery.domain.user.repository.UserAddressRepository;
 import com.baedalping.delivery.domain.user.repository.UserRepository;
 import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
 import com.baedalping.delivery.global.common.exception.ErrorCode;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -59,7 +61,6 @@ public class UserService {
   @Transactional
   public UserAddressResponseDto addAddress(Long userId, String address, String zipcode, String alias){
     User user = findByUser(userId);
-    log.info("{}", user.getUserId());
     UserAddress newAddress = UserAddress.builder()
         .address(address)
         .zipcode(zipcode)
@@ -67,7 +68,15 @@ public class UserService {
         .build();
     user.addAddress(newAddress);
     addressRepository.save(newAddress);
-    return UserAddressResponseDto.fromEntity(user.getUserId(), newAddress);
+    return UserAddressResponseDto.fromEntity(newAddress);
+  }
+
+  public List<UserAddressResponseDto> getAddressList(Long userId){
+    User user = findByUser(userId);
+    return user.getAddressList()
+        .stream()
+        .map(address -> UserAddressResponseDto.fromEntity(address))
+        .collect(Collectors.toList());
   }
 
   private User findByUser(Long userId) {

--- a/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
   NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
   DUPLICATED_USER(HttpStatus.CONFLICT, "이미 가입된 유저 이메일 입니다"),
+  INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "요청 권한이 없습니다"),
 
   NOT_FOUND_STORE_CATEGORY(HttpStatus.NOT_FOUND, "가게 분류를 찾을 수 없습니다."),
   DUPLICATE_STORE_CATEGORY_NAME(HttpStatus.NOT_FOUND, "가게 분류가 중복되었습니다."),

--- a/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
   NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
-  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "가입된 유저가 아닙니다"),
   DUPLICATED_USER(HttpStatus.CONFLICT, "이미 가입된 유저 이메일 입니다"),
 
   NOT_FOUND_STORE_CATEGORY(HttpStatus.NOT_FOUND, "가게 분류를 찾을 수 없습니다."),

--- a/src/test/java/com/baedalping/delivery/user/UserControllerTest.java
+++ b/src/test/java/com/baedalping/delivery/user/UserControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import com.baedalping.delivery.domain.user.controller.UserController;
-import com.baedalping.delivery.domain.user.dto.UserCreateRequestDto;
+import com.baedalping.delivery.domain.user.dto.request.UserCreateRequestDto;
 import com.baedalping.delivery.domain.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/baedalping/delivery/user/UserServiceTest.java
+++ b/src/test/java/com/baedalping/delivery/user/UserServiceTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
-import com.baedalping.delivery.domain.user.dto.UserReadResponseDto;
-import com.baedalping.delivery.domain.user.dto.UserUpdateResponseDto;
+import com.baedalping.delivery.domain.user.dto.response.UserReadResponseDto;
+import com.baedalping.delivery.domain.user.dto.response.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.entity.User;
 import com.baedalping.delivery.domain.user.repository.UserRepository;
 import com.baedalping.delivery.domain.user.service.UserService;


### PR DESCRIPTION
- 유저 아이디를 현재는 PathVariable로 받았으나 추후 Spring context에서 가져오는걸로 수정할 예정입니다 
- 유저 주소 수정 시 주소의 유저 아이디와 요청자의 유저아이디가 같지 않으면 401 예외를 던지는것으로 처리했습니다 
- 시간관계상 유저주소는 테스트 코드를 따로 작성하지 않고 포스트맨 테스트로 진행했습니다
- 
![image](https://github.com/user-attachments/assets/648730c1-8d51-4507-862f-6de80dd87419)
![image](https://github.com/user-attachments/assets/4080e1cf-63d7-47fc-befe-a0ddd597bd14)
![image](https://github.com/user-attachments/assets/62f1fcd4-c264-432c-80a3-b1e72243e8af)
![image](https://github.com/user-attachments/assets/344f94ff-9d6e-4926-9d4d-368adfa71e4e)

