### PR TITLE
feat: 결제 구현 (#23)

### DIFF
--- a/src/main/java/com/baedalping/delivery/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/baedalping/delivery/domain/payment/controller/PaymentController.java
@@ -1,0 +1,47 @@
+package com.baedalping.delivery.domain.payment.controller;
+
+import com.baedalping.delivery.domain.payment.dto.PaymentCreateRequestDto;
+import com.baedalping.delivery.domain.payment.dto.PaymentResponseDto;
+import com.baedalping.delivery.domain.payment.service.PaymentService;
+import com.baedalping.delivery.global.common.ApiResponse;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping
+    public ApiResponse<PaymentResponseDto> createPayment(
+        @RequestBody PaymentCreateRequestDto paymentRequestDto) {
+        return ApiResponse.created(paymentService.createPayment(paymentRequestDto));
+    }
+
+    @GetMapping("/{paymentId}")
+    public ApiResponse<PaymentResponseDto> getPayment(@PathVariable UUID paymentId) {
+        return ApiResponse.ok(paymentService.getPaymentById(paymentId));
+    }
+
+    @GetMapping
+    public ApiResponse<List<PaymentResponseDto>> getAllPayments() {
+        // TODO: 개인 주문 전체조회로 변경예정 - user 권한 이후
+        return ApiResponse.ok(paymentService.getAllPayments());
+    }
+
+    @DeleteMapping("/{paymentId}")
+    public ApiResponse<PaymentResponseDto> deletePayment(@PathVariable UUID paymentId) {
+        // TODO: Admin 권한으로 설정할 예정 - 일반 유저는 Order 취소에서 구현
+        return ApiResponse.ok(paymentService.deletePayment(paymentId));
+    }
+}

--- a/src/main/java/com/baedalping/delivery/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/baedalping/delivery/domain/payment/controller/PaymentController.java
@@ -42,6 +42,6 @@ public class PaymentController {
     @DeleteMapping("/{paymentId}")
     public ApiResponse<PaymentResponseDto> deletePayment(@PathVariable UUID paymentId) {
         // TODO: Admin 권한으로 설정할 예정 - 일반 유저는 Order 취소에서 구현
-        return ApiResponse.ok(paymentService.deletePayment(paymentId));
+        return ApiResponse.ok(paymentService.cancelPayment(paymentId));
     }
 }

--- a/src/main/java/com/baedalping/delivery/domain/payment/dto/PaymentCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/payment/dto/PaymentCreateRequestDto.java
@@ -1,0 +1,20 @@
+package com.baedalping.delivery.domain.payment.dto;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentCreateRequestDto {
+
+    // 외부 결제 모듈에서의 검증을 신뢰한다는 가정 valid 생략
+    private Long userId;
+    private UUID orderId;
+    private String paymentMethod;
+    private int totalAmount;
+
+}

--- a/src/main/java/com/baedalping/delivery/domain/payment/dto/PaymentResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/payment/dto/PaymentResponseDto.java
@@ -1,0 +1,60 @@
+package com.baedalping.delivery.domain.payment.dto;
+
+import com.baedalping.delivery.domain.order.entity.Order;
+import com.baedalping.delivery.domain.payment.entity.Payment;
+import com.baedalping.delivery.domain.payment.entity.PaymentState;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentResponseDto {
+
+    private UUID paymentId;
+    private Long userId;
+    private UUID orderId;
+    private String paymentMethod;
+    private String cardNumber;  // 실제로는 보안 문제로 클라이언트에 전송하지 않는 것이 좋음
+    private PaymentState state;
+    private int totalAmount;
+    private LocalDateTime paymentDate;
+    private Boolean isPublic;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    // 정적 메서드 추가
+    public static PaymentResponseDto fromEntity(Payment payment) {
+        return PaymentResponseDto.builder()
+            .paymentId(payment.getPaymentId())
+            .userId(payment.getUserId())
+            .orderId(payment.getOrderId().getOrderId())  // Order의 orderId 필드 사용
+            .paymentMethod(payment.getPaymentMethod())
+            .cardNumber(null)  // 보안상의 이유로 cardNumber를 null로 설정하거나 마스킹
+            .state(payment.getState())
+            .totalAmount(payment.getTotalAmount())
+            .paymentDate(payment.getPaymentDate())
+            .isPublic(payment.getIsPublic())
+            .createdAt(payment.getCreatedAt())
+            .updatedAt(payment.getUpdatedAt())
+            .deletedAt(payment.getDeletedAt())
+            .build();
+    }
+
+    // 새로운 리스트 변환 메서드
+    public static List<PaymentResponseDto> fromEntities(List<Payment> payments) {
+        return payments.stream()
+            .map(PaymentResponseDto::fromEntity)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/baedalping/delivery/domain/payment/entity/Payment.java
+++ b/src/main/java/com/baedalping/delivery/domain/payment/entity/Payment.java
@@ -1,0 +1,66 @@
+package com.baedalping.delivery.domain.payment.entity;
+
+import com.baedalping.delivery.domain.order.entity.Order;
+import com.baedalping.delivery.global.common.AuditField;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Payment extends AuditField {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "payment_id", updatable = false, nullable = false, columnDefinition = "UUID")
+    private UUID paymentId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order orderId;
+
+    @Column(length = 100)
+    private String paymentMethod;
+
+    @Column(length = 255)
+    private String cardNumber;
+
+    @Setter
+    @Enumerated(EnumType.STRING) // Enum 타입을 문자열로 저장
+    @Column(length = 20)
+    private PaymentState state;
+
+    @Column(precision = 10, scale = 2)
+    private int totalAmount;
+
+    private LocalDateTime paymentDate;
+
+    @Column(nullable = false)
+    private Boolean isPublic = true;
+
+    public void setInvisible() {
+        this.isPublic = false;
+    }
+
+}

--- a/src/main/java/com/baedalping/delivery/domain/payment/entity/PaymentState.java
+++ b/src/main/java/com/baedalping/delivery/domain/payment/entity/PaymentState.java
@@ -1,0 +1,8 @@
+package com.baedalping.delivery.domain.payment.entity;
+
+public enum PaymentState {
+    PENDING,
+    COMPLETE,
+    FAILED,
+    CANCELLED
+}

--- a/src/main/java/com/baedalping/delivery/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/baedalping/delivery/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.baedalping.delivery.domain.payment.repository;
+
+
+import com.baedalping.delivery.domain.payment.entity.Payment;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, UUID> {
+}
+

--- a/src/main/java/com/baedalping/delivery/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/baedalping/delivery/domain/payment/service/PaymentService.java
@@ -67,7 +67,7 @@ public class PaymentService {
     }
 
     @Transactional
-    public PaymentResponseDto deletePayment(UUID paymentId) {
+    public PaymentResponseDto cancelPayment(UUID paymentId) {
         // TODO: user 권한 체크
         Payment payment = getPayment(paymentId);
         payment.setState(PaymentState.CANCELLED);

--- a/src/main/java/com/baedalping/delivery/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/baedalping/delivery/domain/payment/service/PaymentService.java
@@ -1,0 +1,85 @@
+package com.baedalping.delivery.domain.payment.service;
+
+import com.baedalping.delivery.domain.order.entity.Order;
+import com.baedalping.delivery.domain.order.entity.OrderStatus;
+import com.baedalping.delivery.domain.order.repository.OrderRepository;
+import com.baedalping.delivery.domain.payment.dto.PaymentCreateRequestDto;
+import com.baedalping.delivery.domain.payment.dto.PaymentResponseDto;
+import com.baedalping.delivery.domain.payment.entity.Payment;
+import com.baedalping.delivery.domain.payment.entity.PaymentState;
+import com.baedalping.delivery.domain.payment.repository.PaymentRepository;
+import com.baedalping.delivery.global.common.exception.DeliveryApplicationException;
+import com.baedalping.delivery.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public PaymentResponseDto createPayment(PaymentCreateRequestDto paymentRequest) {
+        if (!"CARD".equals(paymentRequest.getPaymentMethod())) {
+            throw new DeliveryApplicationException(ErrorCode.INVALID_PAYMENT_METHOD);
+        }
+
+        Order order = orderRepository.findById(paymentRequest.getOrderId()).orElseThrow(
+            () -> new DeliveryApplicationException(ErrorCode.NOT_FOUND_ORDER)
+        );
+
+        Payment payment = Payment.builder()
+            .userId(paymentRequest.getUserId())
+            .orderId(order)
+            .paymentMethod(paymentRequest.getPaymentMethod())
+            .totalAmount(paymentRequest.getTotalAmount())
+            .paymentDate(LocalDateTime.now())
+            .state(PaymentState.COMPLETE)
+            .isPublic(true)
+            .build();
+
+        Payment savedPayment = paymentRepository.save(payment);
+        order.setState(OrderStatus.CONFIRMED);
+        orderRepository.flush();
+
+        // 정적 팩토리 메서드를 사용하여 DTO 생성
+        // TODO: mapper를 이용한 방법 사용해보기 (order의 순환참조로 인해 명시적 지정이 필요하지만 잘 안됨)
+        return PaymentResponseDto.fromEntity(savedPayment);
+    }
+
+    @Transactional(readOnly = true)
+    public PaymentResponseDto getPaymentById(UUID paymentId) {
+        Payment payment = getPayment(paymentId);
+        return PaymentResponseDto.fromEntity(payment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PaymentResponseDto> getAllPayments() {
+        List<Payment> payments = paymentRepository.findAll();
+        return PaymentResponseDto.fromEntities(payments);
+    }
+
+    @Transactional
+    public PaymentResponseDto deletePayment(UUID paymentId) {
+        // TODO: user 권한 체크
+        Payment payment = getPayment(paymentId);
+        payment.setState(PaymentState.CANCELLED);
+        payment.setInvisible();
+        payment.delete("1L");
+        payment.getOrderId().setState(OrderStatus.CANCELLED);
+        paymentRepository.save(payment);
+        return PaymentResponseDto.fromEntity(payment);
+    }
+
+    private Payment getPayment(UUID paymentId) {
+        return paymentRepository.findById(paymentId)
+            .orElseThrow(() -> new DeliveryApplicationException(ErrorCode.NOT_FOUND_PAYMENT));
+    }
+}

--- a/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
@@ -26,8 +26,11 @@ public enum ErrorCode {
   NOT_FOUND_PRODUCT_IN_CART(HttpStatus.NOT_FOUND, "장바구니에 해당 상품이 존재하지 않습니다."),
 
   // Order
-  NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다.")
-  ;
+  NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
+
+  // Payment
+  NOT_FOUND_PAYMENT(HttpStatus.NOT_FOUND, "존재하지 않는 결제내역입니다."),
+  INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST,"유효하지 않은 결제 방식입니다.");
 
   private final HttpStatus status;
   private final String message;


### PR DESCRIPTION
- 결제 생성 구현
![결제생성](https://github.com/user-attachments/assets/acba200f-580a-45be-a314-9e4efb212c09)

- 결제 단건 조회 구현
![결제 단건 조회](https://github.com/user-attachments/assets/37d9616a-53bc-44e7-9988-793609cd3370)

- 결제 다중 조회 구현
![결제 다중 조회](https://github.com/user-attachments/assets/adea9649-a650-478c-90f6-b9e76289ccde)

- 결제 취소 구현
![결제 취소](https://github.com/user-attachments/assets/42c92632-f646-4808-a09f-d5d666d12759)

*기타사항*
실제 결제 모듈을 외주를 준다는 가정 하에 진행하여 어디까지가 적절한 내용인지 판단하기 힘들었습니다.
구현된 내용에서 수정되었으면 하는 내용이 있으시다면 코멘트 확인 후 적용해보겠습니다.