### PR TITLE
feat: 주문서검색 (#22)

### DIFF
--- a/src/main/java/com/baedalping/delivery/domain/order/controller/OrderController.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/controller/OrderController.java
@@ -6,6 +6,10 @@ import com.baedalping.delivery.domain.order.dto.OrderGetResponseDto;
 import com.baedalping.delivery.domain.order.service.OrderService;
 import com.baedalping.delivery.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -78,10 +82,10 @@ public class OrderController {
     // 주문 키워드 검색
     @GetMapping("/search")
     public ApiResponse<Page<OrderGetResponseDto>> searchOrders(
-        @RequestParam String keyword,
-        @RequestParam(defaultValue = "0") int page,
-        @RequestParam(defaultValue = "10") int size,
-        @RequestParam(defaultValue = "asc") String sortDirection) {
+        @RequestParam @NotBlank String keyword,
+        @RequestParam(defaultValue = "0") @Min(0) int page,
+        @RequestParam(defaultValue = "10") @Min(1) @Max(50) int size,
+        @RequestParam(defaultValue = "asc") @Pattern(regexp = "asc|desc") String sortDirection) {
         return ApiResponse.ok(
             orderService.searchOrdersByKeyword(keyword, page, size, sortDirection));
     }

--- a/src/main/java/com/baedalping/delivery/domain/order/controller/OrderController.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/controller/OrderController.java
@@ -25,6 +25,9 @@ public class OrderController {
 
     private final OrderService orderService;
 
+    /*
+    TODO: body로 받아오고 있는 주문 상세 내역을 Redis에서 가져오도록 변경할 것
+     */
     @PostMapping
     public ApiResponse<OrderCreateResponseDto> createOrder(
         @RequestBody @Valid OrderCreateRequestDto orderRequest) {
@@ -70,16 +73,21 @@ public class OrderController {
             orderService.getOrderById(orderId)
         );
     }
-//
-//    // 주문 키워드 검색
-//    @GetMapping("/search")
-//    public List<Order> searchOrders(@RequestParam String keyword) {
-//        return orderService.searchOrders(keyword);
-//    }
-//
-//
-    // 주문 취소
 
+    //
+    // 주문 키워드 검색
+    @GetMapping("/search")
+    public ApiResponse<Page<OrderGetResponseDto>> searchOrders(
+        @RequestParam String keyword,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size,
+        @RequestParam(defaultValue = "asc") String sortDirection) {
+        return ApiResponse.ok(
+            orderService.searchOrdersByKeyword(keyword, page, size, sortDirection));
+    }
+
+
+    // 주문 취소
     @DeleteMapping("/{orderId}/cancel")
     public ApiResponse<OrderGetResponseDto> cancelOrder(@PathVariable UUID orderId) {
         return ApiResponse.ok(orderService.cancelOrder(orderId));

--- a/src/main/java/com/baedalping/delivery/domain/order/entity/Order.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/entity/Order.java
@@ -1,14 +1,19 @@
 package com.baedalping.delivery.domain.order.entity;
 
+import com.baedalping.delivery.domain.store.entity.Store;
+import com.baedalping.delivery.domain.user.entity.User;
 import com.baedalping.delivery.global.common.AuditField;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -33,11 +38,15 @@ public class Order extends AuditField {
     @Column(name = "order_id", updatable = false, nullable = false, columnDefinition = "UUID")
     private UUID orderId;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false) // JoinColumn을 통해 외래 키 설정
+    private User user;
 
-    @Column(name = "store_id", columnDefinition = "UUID", nullable = false)
-    private UUID storeId;
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false, columnDefinition = "UUID") // JoinColumn을 통해 외래 키 설정
+    private Store store;
 
     @Setter
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -54,7 +63,7 @@ public class Order extends AuditField {
     @Setter
     @Enumerated(EnumType.STRING)
     @Column(name = "order_type", length = 20, nullable = false)
-    private OrderType orderType = OrderType.ONLINE;
+    private OrderType orderType;
 
     @Setter
     @Column(name = "total_quantity", nullable = false)
@@ -69,10 +78,4 @@ public class Order extends AuditField {
 
     @Column(name = "is_public", nullable = false)
     private Boolean isPublic = true;
-
-
-
-
-
-
 }

--- a/src/main/java/com/baedalping/delivery/domain/order/entity/OrderDetail.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/entity/OrderDetail.java
@@ -1,5 +1,6 @@
 package com.baedalping.delivery.domain.order.entity;
 
+import com.baedalping.delivery.domain.product.entity.Product;
 import com.baedalping.delivery.global.common.AuditField;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -36,8 +37,10 @@ public class OrderDetail extends AuditField {
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
 
-    @Column(name = "product_id", columnDefinition = "UUID", nullable = false)
-    private UUID productId;
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false, columnDefinition = "UUID")
+    private Product product;
 
     @Column(name = "product_name", length = 255, nullable = false)
     private String productName;
@@ -51,6 +54,4 @@ public class OrderDetail extends AuditField {
     @Setter
     @Column(name = "subtotal",  nullable = false)
     private Integer subtotal;
-
-
 }

--- a/src/main/java/com/baedalping/delivery/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/baedalping/delivery/domain/order/repository/OrderRepository.java
@@ -6,12 +6,33 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface OrderRepository extends JpaRepository<Order, UUID> {
+public interface OrderRepository extends JpaRepository<Order, UUID> ,
+    JpaSpecificationExecutor<Order> {
 
-    Page<Order> findByStoreIdAndIsPublicTrue(UUID storeId, Pageable pageable);
+    Page<Order> findByStore_StoreIdAndIsPublicTrue(UUID storeId, Pageable pageable);
 
-    Page<Order> findByUserIdAndIsPublicTrue(Long userId, Pageable pageable);
+    Page<Order> findByUser_UserIdAndIsPublicTrue(Long userId, Pageable pageable);
+
+
+    // JPQL을 사용하여 특정 키워드를 포함하는 모든 결과를 검색
+    @Query("SELECT DISTINCT o FROM Order o " +
+        "JOIN o.store s " +
+        "JOIN s.storeCategory sc " +
+        "JOIN o.orderDetails od " +
+        "JOIN od.product p " +
+        "JOIN p.productCategory pc " +
+        "WHERE o.isPublic = true " +
+        "AND (" +
+        "LOWER(s.storeName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+        "OR LOWER(sc.storeCategoryName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+        "OR LOWER(p.productName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+        "OR LOWER(pc.productCategoryName) LIKE LOWER(CONCAT('%', :keyword, '%'))" +
+        ")")
+    Page<Order> findOrdersByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/baedalping/delivery/global/common/exception/ErrorCode.java
@@ -27,7 +27,7 @@ public enum ErrorCode {
 
   // Order
   NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
-  CANNOT_CANCEL_ORDER_AFTER_5_MINUTES(HttpStatus.FORBIDDEN,"주문은 5분 이내에만 취소 가능합니다." );
+  CANNOT_CANCEL_ORDER_AFTER_5_MINUTES(HttpStatus.FORBIDDEN,"주문은 5분 이내에만 취소 가능합니다." ),
 
   // Payment
   NOT_FOUND_PAYMENT(HttpStatus.NOT_FOUND, "존재하지 않는 결제내역입니다."),


### PR DESCRIPTION
- 연관관계 수정
- 주문서 검색 (이름, 카테고리 필드)

![검색기능 구현](https://github.com/user-attachments/assets/51c9a643-e0cf-4d6f-b84f-a2774a05323e)
(상품, 가게의 이름, 카테고리 중 1개가 키워드를 포함할 경우 검색에 포함)

기타사항

- 추후 쿼리 성능 체크 이후 개선 계획
- user 검증의 경우 별도 이슈 생성예정
- service에 repository를 가져와 사용한 내용은 기능 체크 이후 리팩토링 때 수정(순환참조 가능성 있음)