### PR TITLE
심화기능 - 유저권한 캐싱하고 유저 권한변경 시 캐시된 값 업데이트 하기 (#32)

### DIFF
--- a/src/main/java/com/baedalping/delivery/domain/auth/AuthController.java
+++ b/src/main/java/com/baedalping/delivery/domain/auth/AuthController.java
@@ -1,0 +1,25 @@
+package com.baedalping.delivery.domain.auth;
+
+import com.baedalping.delivery.domain.auth.dto.UserCreateRequestDto;
+import com.baedalping.delivery.domain.auth.dto.UserCreateResponseDto;
+import com.baedalping.delivery.domain.user.service.UserService;
+import com.baedalping.delivery.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+  private final UserService userService;
+  @PostMapping
+  public ApiResponse<UserCreateResponseDto> create(
+      @RequestBody @Validated UserCreateRequestDto requestDto) {
+    return ApiResponse.created(
+        userService.create(requestDto.username(), requestDto.password(), requestDto.email()));
+  }
+}

--- a/src/main/java/com/baedalping/delivery/domain/auth/dto/UserCreateRequestDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/auth/dto/UserCreateRequestDto.java
@@ -1,4 +1,4 @@
-package com.baedalping.delivery.domain.user.dto.request;
+package com.baedalping.delivery.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/baedalping/delivery/domain/auth/dto/UserCreateResponseDto.java
+++ b/src/main/java/com/baedalping/delivery/domain/auth/dto/UserCreateResponseDto.java
@@ -1,4 +1,4 @@
-package com.baedalping.delivery.domain.user.dto.response;
+package com.baedalping.delivery.domain.auth.dto;
 
 import com.baedalping.delivery.domain.user.entity.User;
 import java.time.LocalDateTime;

--- a/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/controller/UserController.java
@@ -2,10 +2,8 @@ package com.baedalping.delivery.domain.user.controller;
 
 import com.baedalping.delivery.domain.user.dto.request.UserAddressCreateRequestDto;
 import com.baedalping.delivery.domain.user.dto.request.UserAddressUpdateRequestDto;
-import com.baedalping.delivery.domain.user.dto.request.UserCreateRequestDto;
 import com.baedalping.delivery.domain.user.dto.request.UserUpdateRequestDto;
 import com.baedalping.delivery.domain.user.dto.response.UserAddressResponseDto;
-import com.baedalping.delivery.domain.user.dto.response.UserCreateResponseDto;
 import com.baedalping.delivery.domain.user.dto.response.UserReadResponseDto;
 import com.baedalping.delivery.domain.user.dto.response.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.service.UserService;
@@ -28,13 +26,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/users")
 public class UserController {
   private final UserService userService;
-
-  @PostMapping
-  public ApiResponse<UserCreateResponseDto> create(
-      @RequestBody @Validated UserCreateRequestDto requestDto) {
-    return ApiResponse.created(
-        userService.create(requestDto.username(), requestDto.password(), requestDto.email()));
-  }
 
   @GetMapping("/{userId}")
   public ApiResponse<UserReadResponseDto> get(@PathVariable("userId") Long userId) {

--- a/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/service/UserService.java
@@ -1,7 +1,7 @@
 package com.baedalping.delivery.domain.user.service;
 
 import com.baedalping.delivery.domain.user.dto.response.UserAddressResponseDto;
-import com.baedalping.delivery.domain.user.dto.response.UserCreateResponseDto;
+import com.baedalping.delivery.domain.auth.dto.UserCreateResponseDto;
 import com.baedalping.delivery.domain.user.dto.response.UserReadResponseDto;
 import com.baedalping.delivery.domain.user.dto.response.UserUpdateResponseDto;
 import com.baedalping.delivery.domain.user.entity.User;

--- a/src/main/java/com/baedalping/delivery/global/config/RedisConfig.java
+++ b/src/main/java/com/baedalping/delivery/global/config/RedisConfig.java
@@ -1,14 +1,22 @@
 package com.baedalping.delivery.global.config;
 
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@EnableCaching
 public class RedisConfig {
 
   @Bean
@@ -23,5 +31,18 @@ public class RedisConfig {
     template.setKeySerializer(new StringRedisSerializer());
     template.setValueSerializer(new GenericToStringSerializer<>(Object.class));
     return template;
+  }
+
+  @Bean
+  public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+    RedisCacheConfiguration configuration =
+        RedisCacheConfiguration.defaultCacheConfig()
+            .disableCachingNullValues()
+            .entryTtl(Duration.ofHours(1))
+            .computePrefixWith(CacheKeyPrefix.simple())
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(RedisSerializer.java()));
+
+    return RedisCacheManager.builder(redisConnectionFactory).cacheDefaults(configuration).build();
   }
 }

--- a/src/main/java/com/baedalping/delivery/global/security/SecurityConfig.java
+++ b/src/main/java/com/baedalping/delivery/global/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.baedalping.delivery.global.security;
 
 import com.baedalping.delivery.global.utils.JwtTokenUtils;
+import com.baedalping.delivery.global.utils.RedisComponent;
 import com.baedalping.delivery.global.utils.UserDetailServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +23,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
   private final JwtTokenUtils jwtUtil;
   private final UserDetailServiceImpl userDetailService;
+  private final RedisComponent redisService;
   private final AuthenticationConfiguration authenticationConfiguration;
   private final AuthenticationEntryPoint entryPoint;
 
@@ -33,7 +35,7 @@ public class SecurityConfig {
 
   @Bean
   public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
-    JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+    JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, redisService);
     filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
     return filter;
   }

--- a/src/main/java/com/baedalping/delivery/global/utils/RedisComponent.java
+++ b/src/main/java/com/baedalping/delivery/global/utils/RedisComponent.java
@@ -1,0 +1,15 @@
+package com.baedalping.delivery.global.utils;
+
+import com.baedalping.delivery.domain.user.dto.response.UserAuthorityResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j(topic = "RedisService")
+public class RedisComponent {
+  @Cacheable(cacheNames = "roleCache", key = "args[0]")
+  public UserAuthorityResponseDto setUserAuthorityInRedis(String email, String role) {
+    return new UserAuthorityResponseDto(email, role);
+  }
+}

--- a/src/test/java/com/baedalping/delivery/user/UserControllerTest.java
+++ b/src/test/java/com/baedalping/delivery/user/UserControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import com.baedalping.delivery.domain.user.controller.UserController;
-import com.baedalping.delivery.domain.user.dto.request.UserCreateRequestDto;
+import com.baedalping.delivery.domain.auth.dto.UserCreateRequestDto;
 import com.baedalping.delivery.domain.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- 캐시매니저 빈 Redis Config에 추가 
- 로그인 처리하는 필터에서 로그인 성공시 redis에 key: email, value: role(:String)의 값을 캐싱 
- 유저의 아이디와 변경할 롤을 받아 유저의 권한을 변경하는 어드민용 API 추가 
 - 변경정보 db에 업데이트하면서 캐시의 유저권한도 변경 
 - 회원가입의 엔드포인트를 /auth 로 변경