### PR TITLE
심화기능 - 스프링 클라우드 게이트웨이로 유저 인증 분리하기 (#35)

### DIFF
--- a/src/main/java/com/baedalping/delivery/global/config/RedisConfig.java
+++ b/src/main/java/com/baedalping/delivery/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.baedalping.delivery.global.config;
 
+import com.baedalping.delivery.domain.user.dto.response.UserAuthorityResponseDto;
 import java.time.Duration;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -11,8 +12,8 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -35,13 +36,20 @@ public class RedisConfig {
 
   @Bean
   public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+    StringRedisSerializer stringRedisSerializer = new StringRedisSerializer();
+
+    RedisSerializationContext.SerializationPair<UserAuthorityResponseDto> jsonSerializer =
+        RedisSerializationContext.SerializationPair.fromSerializer(
+            new Jackson2JsonRedisSerializer<>(UserAuthorityResponseDto.class));
+
     RedisCacheConfiguration configuration =
         RedisCacheConfiguration.defaultCacheConfig()
             .disableCachingNullValues()
             .entryTtl(Duration.ofHours(1))
             .computePrefixWith(CacheKeyPrefix.simple())
-            .serializeValuesWith(
-                RedisSerializationContext.SerializationPair.fromSerializer(RedisSerializer.java()));
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(stringRedisSerializer))
+            .serializeValuesWith(jsonSerializer);
 
     return RedisCacheManager.builder(redisConnectionFactory).cacheDefaults(configuration).build();
   }

--- a/src/main/java/com/baedalping/delivery/global/security/SecurityConfig.java
+++ b/src/main/java/com/baedalping/delivery/global/security/SecurityConfig.java
@@ -6,7 +6,6 @@ import com.baedalping.delivery.global.utils.UserDetailServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -41,8 +40,8 @@ public class SecurityConfig {
   }
 
   @Bean
-  public JwtAuthorizationFilter jwtAuthorizationFilter() {
-    return new JwtAuthorizationFilter(jwtUtil, userDetailService);
+  public UserAuthorizationFilter userAuthorizationFilter() {
+    return new UserAuthorizationFilter(jwtUtil, userDetailService);
   }
 
   @Bean
@@ -58,7 +57,7 @@ public class SecurityConfig {
                     .permitAll()
                     .anyRequest()
                     .authenticated())
-        .addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class)
+        .addFilterBefore(userAuthorizationFilter(), JwtAuthenticationFilter.class)
         .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(
             (exceptionHandling) -> exceptionHandling.authenticationEntryPoint(entryPoint));


### PR DESCRIPTION
- /auth/login(로그인), /auth(회원가입)은 gateway에서 필터링이 이루어지지 않고 통과되며 기존 order-service에 있는 로그인 필터에서 진행하는것으로 되어있습니다. 로그인에 성공하면 해당 로그인한 유저의 이메일로 권한정보가 redis에 저장됩니다.
- 이외 나머지 모든 요청은 gateway에서 토큰검증을 하고 해당 API의 권한과 요청한 유저의 권한이 맞는지 redis에서 조회하는 필터를 추가하여 토큰 검증 및 권한들이 맞아야 order-service로 전달되게끔 구현하였습니다 
- MSA로 전환되면서 저희 배달핑 organazation에 있는 eureka, gateway, order-service를 띄워놔야 테스트가 가능하니 확인하시고 진행하시길 바랍니다

- 모든 테스트 캡처는 localhost:19091 (게이트웨이주소)로 진행하여 올려주시길 바랍니다 
1. 로그인
![image](https://github.com/user-attachments/assets/6dbe351e-d15f-40d6-9c3e-1770317492fb)

2. 회원가입
![image](https://github.com/user-attachments/assets/0c1a7612-40e5-40e1-81e0-4ed116ced313)

3. 유저정보 업데이트
![image](https://github.com/user-attachments/assets/c238f799-c6a7-44bd-aba2-ee504530914c)

4. 유저정보조회
![image](https://github.com/user-attachments/assets/a09d37cd-a90e-4d72-8c93-4887f7d8eb05)

5. 유저주소 등록
![image](https://github.com/user-attachments/assets/4b655ec0-86fc-49ff-b913-18970028538a)

6. 유저주소 목록 조회
![image](https://github.com/user-attachments/assets/275e5cf8-9a16-435e-8140-35a8055be69e)

7. 유저 주소 정보 수정
![image](https://github.com/user-attachments/assets/5937e109-09ed-409b-be39-dc9c9d0393ab)

8. 유저삭제
![image](https://github.com/user-attachments/assets/37ad007f-0fb6-4e18-b88d-4538f05afe03)

