### PR TITLE
fix: 관리자 권한변경 API에서 CacheEvict key변경

### DIFF
--- a/src/main/java/com/baedalping/delivery/domain/user/service/AdminService.java
+++ b/src/main/java/com/baedalping/delivery/domain/user/service/AdminService.java
@@ -17,7 +17,7 @@ public class AdminService {
   private final UserRepository userRepository;
 
   @Transactional
-  @CacheEvict(cacheNames = "roleCache", key = "#user.email")
+  @CacheEvict(cacheNames = "roleCache", key = "#result.email")
   public UserAuthorityResponseDto updateUserRole(Long userId, UserRole role) {
     User user = findByUserId(userId);
     user.updateUserRole(role);


### PR DESCRIPTION
- 관리자 권한변경 API 테스트 추가 및 해당 기능에서 @CacheEvict key를 결과에 있는 이메일로 쓰도록 수정 
- 로그인을 한 유저면 redis에 권한정보가 저장되어있어서 변경한 role로 업데이트 +  db에도 변경한 롤로 저장이 되고 로그인을 안한 유저면 redis에 값이 권한정보가 없을것이므로 db에만 변경된 권한으로 수정하고 넘어감 
![image](https://github.com/user-attachments/assets/ff2258e0-b972-4a36-9ffb-03fc400b5db3)


